### PR TITLE
config: Switch to logging to /var/log/datadog/process-agent.log

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -72,7 +72,7 @@ func main() {
 	flag.Parse()
 
 	// Set up a default config before parsing config so we log errors nicely.
-	if err := NewLoggerLevelCustom("info"); err != nil {
+	if err := config.NewLoggerLevel("info"); err != nil {
 		panic(err)
 	}
 
@@ -100,11 +100,6 @@ func main() {
 	if err != nil {
 		log.Criticalf("Error parsing config: %s", err)
 		os.Exit(1)
-	}
-
-	// Once config is parsed we can change the log level.
-	if err := NewLoggerLevelCustom(cfg.LogLevel); err != nil {
-		panic(err)
 	}
 
 	// Exit if agent is is not enabled and we're not debugging a check.

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type AgentConfig struct {
 	Concurrency   int
 	Proxy         *url.URL
 	Timers        *CheckTimers
+	Logger        *LoggerConfig
 }
 
 const (
@@ -168,7 +169,12 @@ func NewAgentConfig(agentConf, legacyConf *File) (*AgentConfig, error) {
 		t.RealTime = time.NewTicker(file.GetDurationDefault(ns, "realtime_interval", time.Second, 2*time.Second))
 	}
 
-	return mergeEnv(cfg), nil
+	cfg = mergeEnv(cfg)
+
+	// (Re)configure the logging from our configuration
+	NewLoggerLevel(cfg.LogLevel)
+
+	return cfg, nil
 }
 
 // mergeEnv applies overrides from environment variables to the trace agent configuration


### PR DESCRIPTION
* Update logging code to support file path configuration.
* We default to /var/log/datadog/process-agent.log for logging now to remain consistent with the rest of the Agent