### PR TITLE
Rework cgroup collection to determine pids from cgroup procs file.

### DIFF
--- a/checks/process.go
+++ b/checks/process.go
@@ -61,7 +61,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	for _, fp := range fps {
 		pids = append(pids, fp.Pid)
 	}
-	containerByPID, err := docker.ContainersByPID(pids)
+	containerByPID, err := docker.ContainersByPID()
 	if err != nil && err != docker.ErrDockerNotAvailable && err.Error() != lastDockerErr {
 		// Limit docker error logging to once per Agent run to prevent noise when permissions
 		// aren't correct.

--- a/checks/real_time.go
+++ b/checks/real_time.go
@@ -37,7 +37,7 @@ func (r *RealTimeCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mes
 	for _, fp := range fps {
 		pids = append(pids, fp.Pid)
 	}
-	containerByPID, err := docker.ContainersByPID(pids)
+	containerByPID, err := docker.ContainersByPID()
 	if err != nil && err != docker.ErrDockerNotAvailable && err.Error() != lastDockerErr {
 		// Limit docker error logging to once per Agent run to prevent noise when permissions
 		// aren't correct.

--- a/util/util.go
+++ b/util/util.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+var e = struct{}{}
+
 // ReadLines reads contents from a file and splits them by new lines.
 func ReadLines(filename string) ([]string, error) {
 	f, err := os.Open(filename)
@@ -62,4 +64,57 @@ func PathExists(filename string) bool {
 		return true
 	}
 	return false
+}
+
+// Int32Set is a small map-backed implementation of a set. Not
+// thread-safe.
+type Int32Set map[int32]struct{}
+
+// NewInt32Set returns a new empty int32 set.
+func NewInt32Set() Int32Set {
+	return make(Int32Set)
+}
+
+// Int32SetFromSlice creates a set from the given slice.
+func Int32SetFromSlice(slice []int32) Int32Set {
+	s := NewInt32Set()
+	s.Fill(slice)
+	return s
+}
+
+// Add adds a key to the set.
+func (ss Int32Set) Add(key int32) {
+	ss[key] = e
+}
+
+// Delete removes a key from the set
+func (ss Int32Set) Delete(key int32) {
+	delete(ss, key)
+}
+
+// Fill adds many keys to the set.
+func (ss Int32Set) Fill(keys []int32) {
+	for _, k := range keys {
+		ss[k] = e
+	}
+}
+
+// Contains returns true if the key is in the set, false otherwise.
+func (ss Int32Set) Contains(key int32) bool {
+	_, ok := ss[key]
+	return ok
+}
+
+// Len returns then number of elements in the set.
+func (ss Int32Set) Len() int {
+	return len(ss)
+}
+
+// Elements returns the elements in the set as a slice.
+func (ss Int32Set) Elements() []int32 {
+	keys := make([]int32, 0, len(ss))
+	for k := range ss {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
This should limit the number of syscalls required by a good margin
because we will only read files for processes that are actually
controlled by a container. In the current version we check the cgroup
info for every live process on the system which leads to unnecesary
work and overhead.