### PR TITLE
Refactor docker and k8s to use a singleton util with module-level funcs.

### DIFF
--- a/checks/real_time.go
+++ b/checks/real_time.go
@@ -53,12 +53,9 @@ func (r *RealTimeCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mes
 	for _, fp := range fps {
 		pids = append(pids, fp.Pid)
 	}
-	containerByPID, err := docker.ContainersByPID(pids)
-	if err != nil && err != docker.ErrDockerNotAvailable && err.Error() != lastDockerErr {
-		// Limit docker error logging to once per Agent run to prevent noise when permissions
-		// aren't correct.
+	containerByPID, err := docker.ContainersForPIDs(pids)
+	if err != nil {
 		log.Warnf("unable to get docker stats: %s", err)
-		lastDockerErr = err.Error()
 	}
 
 	// Pre-filter the list to get an accurate grou psize.


### PR DESCRIPTION
Refactor the {kube,docker}util to use a singleton for all calls. All functions are now called from the module level (e.g. `docker.ContainersForPids`) and methods of dockerutil are unexported, as is the global. This helps keep a cleaner API and also doesn't force us to push more metadata utils/providers into the checks (e.g. some ECSUtil, when it exists) and just have them initialized at start.

Also allows us to close #2 as we're only handling the docker/k8s configuration errors at the start. If they error once then the utility won't be used throughout all collections. For errors that happen within the check I think we can safely log them many times because they will be "real" - i.e. not due to permissions issues.

All in all, this should be a no-op.