### PR TITLE
[proc] Update logging configuration

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -74,7 +74,8 @@ func main() {
 	flag.Parse()
 
 	// Set up a default config before parsing config so we log errors nicely.
-	if err := config.NewLoggerLevel("info"); err != nil {
+	// The default will be stdout since we can't assume any file is writeable.
+	if err := config.NewLoggerLevel("info", ""); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
* Support custom log file location.
* Support stdout logging via DD_LOGS_STDOUT env variable.
* Rotate file logs by default at 10MB size.

To change the log file, you would add in `datadog.conf`:

```
[process.config]
log_file = /var/log/datadog/whatever.log
```