### PR TITLE
Support mac/darwin

### DIFF
--- a/checks/net.go
+++ b/checks/net.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
+	"github.com/DataDog/datadog-process-agent/util"
 )
 
 // ConnectionsCheck collects statistics about live TCP and UDP connections.
@@ -29,7 +30,9 @@ func (c *ConnectionsCheck) Name() string { return "connections" }
 func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	start := time.Now()
 	connections, err := net.ConnectionsMax("tcp", cfg.MaxProcFDs)
-	if err != nil {
+	if err != nil && err.Error() == util.ErrNotImplemented.Error() {
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/checks/real_time.go
+++ b/checks/real_time.go
@@ -6,8 +6,6 @@ import (
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
 	"github.com/DataDog/datadog-process-agent/util/docker"
@@ -53,10 +51,7 @@ func (r *RealTimeCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mes
 	for _, fp := range fps {
 		pids = append(pids, fp.Pid)
 	}
-	containerByPID, err := docker.ContainersForPIDs(pids)
-	if err != nil {
-		log.Warnf("unable to get docker stats: %s", err)
-	}
+	containerByPID := docker.ContainersForPIDs(pids)
 
 	// Pre-filter the list to get an accurate grou psize.
 	filteredFps := make([]*process.FilledProcess, 0, len(fps))

--- a/util/util.go
+++ b/util/util.go
@@ -2,10 +2,16 @@ package util
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// ErrNotImplemented is the "not implemented" error given by `gopsutil` when an
+// OS doesn't support and API. Unfortunately it's in an internal package so
+// we can't import it so we'll copy it here.
+var ErrNotImplemented = errors.New("not implemented yet")
 
 // ReadLines reads contents from a file and splits them by new lines.
 func ReadLines(filename string) ([]string, error) {


### PR DESCRIPTION
Much of the work is in https://github.com/DataDog/gopsutil/pull/10

On the Agent side we:

* Made the Docker check not error/warn on mac, it's just silently skipped. Getting Docker working on mac (with stats, at least) is a whole can of worms for later on.
* Added some additional checks for cases where Mac isn't supported yet (e.g. IOStats, Net stats)

Now it builds and runs!