### PR TITLE
Configurable flag for docker health, network collection.

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -142,7 +142,7 @@ func main() {
 }
 
 func initMetadataProviders(cfg *config.AgentConfig) {
-	err := docker.InitDockerUtil()
+	err := docker.InitDockerUtil(cfg.CollectDockerHealth, cfg.CollectDockerNetwork)
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		log.Errorf("unable to initialize docker collection: %s", err)
 	}


### PR DESCRIPTION
Both of these collections can be heavier on the system because they require calling inspect on every container. We'll add them as flags just in case someone wants to shut them off.