### PR TITLE
Refactor check config to support dynamic checks.

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -183,22 +183,15 @@ func debugCheckResults(cfg *config.AgentConfig, check string) error {
 		return err
 	}
 
-	var ch checks.Check
-	switch check {
-	case "process":
-		ch = checks.NewProcessCheck(cfg, sysInfo)
-	case "process_realtime":
-		ch = checks.NewRTProcessCheck(cfg, sysInfo)
-	case "connections":
-		ch = checks.NewConnectionsCheck(cfg, sysInfo)
-	case "container":
-		ch = checks.NewContainerCheck(cfg, sysInfo)
-	case "container_realtime":
-		ch = checks.NewRTContainerCheck(cfg, sysInfo)
-	default:
-		return fmt.Errorf("invalid check: %s", check)
+	names := make([]string, 0, len(checks.All))
+	for _, ch := range checks.All {
+		if ch.Name() == check {
+			ch.Init(cfg, sysInfo)
+			return printResults(cfg, ch)
+		}
+		names = append(names, ch.Name())
 	}
-	return printResults(cfg, ch)
+	return fmt.Errorf("invalid check '%s', choose from: %v", check, names)
 }
 
 func printResults(cfg *config.AgentConfig, ch checks.Check) error {

--- a/checks/checks.go
+++ b/checks/checks.go
@@ -8,7 +8,19 @@ import (
 // Check is an interface for Agent checks that collect data. Each check returns
 // a specific MessageBody type that will be published to the intake endpoint or
 // processed in another way (e.g. printed for debugging).
+// Before checks are used you must called Init.
 type Check interface {
+	Init(cfg *config.AgentConfig, info *model.SystemInfo)
 	Name() string
+	RealTime() bool
 	Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error)
+}
+
+// All is all the singleton check instances.
+var All = []Check{
+	Process,
+	RTProcess,
+	Container,
+	RTContainer,
+	Connections,
 }

--- a/checks/container.go
+++ b/checks/container.go
@@ -16,6 +16,8 @@ import (
 
 const nanoSecondsPerSecond uint64 = 10e9
 
+var Container = &ContainerCheck{}
+
 // ContainerCheck is a check that returns container metadata and stats.
 type ContainerCheck struct {
 	sysInfo        *model.SystemInfo
@@ -24,13 +26,16 @@ type ContainerCheck struct {
 	lastRun        time.Time
 }
 
-// NewContainerCheck returns a new ContainerCheck
-func NewContainerCheck(cfg *config.AgentConfig, info *model.SystemInfo) *ContainerCheck {
-	return &ContainerCheck{sysInfo: info}
+// Init initializes a ContainerCheck instance.
+func (c *ContainerCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
+	c.sysInfo = info
 }
 
 // Name returns the name of the ProcessCheck.
 func (c *ContainerCheck) Name() string { return "container" }
+
+// RealTime indicates if this check only runs in real-time mode.
+func (c *ContainerCheck) RealTime() bool { return false }
 
 // Run runs the ContainerCheck to collect a list of running containers and the
 // stats for each container.

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DataDog/datadog-process-agent/util/docker"
 )
 
+var RTContainer = &RTContainerCheck{}
+
 // RTContainerCheck collects numeric statistics about live containers.
 type RTContainerCheck struct {
 	sysInfo        *model.SystemInfo
@@ -19,13 +21,16 @@ type RTContainerCheck struct {
 	lastRun        time.Time
 }
 
-// NewRTContainerCheck returns a new RTContainerCheck.
-func NewRTContainerCheck(cfg *config.AgentConfig, sysInfo *model.SystemInfo) *RTContainerCheck {
-	return &RTContainerCheck{sysInfo: sysInfo}
+// Init initializes a RTContainerCheck instance.
+func (r *RTContainerCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemInfo) {
+	r.sysInfo = sysInfo
 }
 
 // Name returns the name of the RTContainerCheck.
-func (r *RTContainerCheck) Name() string { return "rt-container" }
+func (r *RTContainerCheck) Name() string { return "rtcontainer" }
+
+// RealTime indicates if this check only runs in real-time mode.
+func (c *RTContainerCheck) RealTime() bool { return false }
 
 func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	cpuTimes, err := cpu.Times(false)

--- a/checks/net.go
+++ b/checks/net.go
@@ -11,16 +11,19 @@ import (
 	"github.com/DataDog/datadog-process-agent/util"
 )
 
+var Connections = &ConnectionsCheck{}
+
 // ConnectionsCheck collects statistics about live TCP and UDP connections.
 type ConnectionsCheck struct{}
 
-// NewConnectionsCheck returns a new ConnectionsCheck instance.
-func NewConnectionsCheck(cfg *config.AgentConfig, sysInfo *model.SystemInfo) *ConnectionsCheck {
-	return &ConnectionsCheck{}
-}
+// Init initializes a ConnectionsCheck instance.
+func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemInfo) {}
 
 // Name returns the name of the ConnectionsCheck.
 func (c *ConnectionsCheck) Name() string { return "connections" }
+
+// RealTime indicates if this check only runs in real-time mode.
+func (c *ConnectionsCheck) RealTime() bool { return false }
 
 // Run runs the ConnectionsCheck to collect the live TCP connections on the
 // system. In most POSIX systems we will use the procfs net files to read out

--- a/checks/process.go
+++ b/checks/process.go
@@ -17,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-process-agent/util/kubernetes"
 )
 
+var Process = &ProcessCheck{}
+
 // ProcessCheck collects full state, including cmdline args and related metadata,
 // for live and running processes. The instance will store some state between
 // checks that will be used for rates, cpu calculations, etc.
@@ -30,15 +32,16 @@ type ProcessCheck struct {
 
 // NewProcessCheck returns a new ProcessCheck initialized with a connection to
 // Kubernetes (if appliable) and other zeoes-out information.
-func NewProcessCheck(cfg *config.AgentConfig, info *model.SystemInfo) *ProcessCheck {
-	return &ProcessCheck{
-		sysInfo:   info,
-		lastProcs: make(map[int32]*process.FilledProcess),
-	}
+func (p *ProcessCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
+	p.sysInfo = info
+	p.lastProcs = make(map[int32]*process.FilledProcess)
 }
 
 // Name returns the name of the ProcessCheck.
 func (p *ProcessCheck) Name() string { return "process" }
+
+// RealTime indicates if this check only runs in real-time mode.
+func (c *ProcessCheck) RealTime() bool { return false }
 
 // Run runs the ProcessCheck to collect a list of running processes and relevant
 // stats for each. On most POSIX systems this will use a mix of procfs and other

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DataDog/datadog-process-agent/util/docker"
 )
 
+var RTProcess = &RTProcessCheck{}
+
 // RTProcessCheck collects numeric statistics about the live processes.
 // The instance stores state between checks for calculation of rates and CPU.
 type RTProcessCheck struct {
@@ -21,15 +23,16 @@ type RTProcessCheck struct {
 	lastRun        time.Time
 }
 
-// NewRTProcessCheck returns a new RTProcessCheck instance.
-func NewRTProcessCheck(cfg *config.AgentConfig, sysInfo *model.SystemInfo) *RTProcessCheck {
-	return &RTProcessCheck{
-		sysInfo:   sysInfo,
-		lastProcs: make(map[int32]*process.FilledProcess)}
+// Init initializes a new RTProcessCheck instance.
+func (r *RTProcessCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
+	r.sysInfo = info
 }
 
 // Name returns the name of the RTProcessCheck.
-func (r *RTProcessCheck) Name() string { return "real-time" }
+func (r *RTProcessCheck) Name() string { return "rtprocess" }
+
+// RealTime indicates if this check only runs in real-time mode.
+func (c *RTProcessCheck) RealTime() bool { return true }
 
 // Run runs the RTProcessCheck to collect statistics about the running processes.
 // On most POSIX systems these statistics are collected from procfs. The bulk

--- a/util/util.go
+++ b/util/util.go
@@ -74,3 +74,13 @@ func PathExists(filename string) bool {
 	}
 	return false
 }
+
+// StringInSlice returns true if the given searchString is in the given slice, false otherwise.
+func StringInSlice(slice []string, searchString string) bool {
+	for _, curString := range slice {
+		if curString == searchString {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Changes the config model from using hardcoded lists of checks and
configuration to pulling from all available checks and configuring each.
This will allow us to have different sets of checks running in different
instances (e.g. a container-only agent).

Right now we're always using same checks (process+rtprocess) but we will
have this toggle between this and (container+rtcontainer) in a later
change.