### PR TITLE
Support different endpoints per check

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -12,6 +12,7 @@ import (
 type Check interface {
 	Init(cfg *config.AgentConfig, info *model.SystemInfo)
 	Name() string
+	Endpoint() string
 	RealTime() bool
 	Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error)
 }

--- a/checks/container.go
+++ b/checks/container.go
@@ -34,6 +34,9 @@ func (c *ContainerCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 // Name returns the name of the ProcessCheck.
 func (c *ContainerCheck) Name() string { return "container" }
 
+// Endpoint returns the endpoint where this check is submitted.
+func (c *ContainerCheck) Endpoint() string { return "/api/v1/container" }
+
 // RealTime indicates if this check only runs in real-time mode.
 func (c *ContainerCheck) RealTime() bool { return false }
 

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -29,6 +29,9 @@ func (r *RTContainerCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 // Name returns the name of the RTContainerCheck.
 func (r *RTContainerCheck) Name() string { return "rtcontainer" }
 
+// Endpoint returns the endpoint where this check is submitted.
+func (c *RTContainerCheck) Endpoint() string { return "/api/v1/container" }
+
 // RealTime indicates if this check only runs in real-time mode.
 func (c *RTContainerCheck) RealTime() bool { return false }
 

--- a/checks/net.go
+++ b/checks/net.go
@@ -22,6 +22,9 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 // Name returns the name of the ConnectionsCheck.
 func (c *ConnectionsCheck) Name() string { return "connections" }
 
+// Endpoint returns the endpoint where this check is submitted.
+func (c *ConnectionsCheck) Endpoint() string { return "/api/v1/collector" }
+
 // RealTime indicates if this check only runs in real-time mode.
 func (c *ConnectionsCheck) RealTime() bool { return false }
 

--- a/checks/process.go
+++ b/checks/process.go
@@ -40,6 +40,9 @@ func (p *ProcessCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 // Name returns the name of the ProcessCheck.
 func (p *ProcessCheck) Name() string { return "process" }
 
+// Endpoint returns the endpoint where this check is submitted.
+func (c *ProcessCheck) Endpoint() string { return "/api/v1/collector" }
+
 // RealTime indicates if this check only runs in real-time mode.
 func (c *ProcessCheck) RealTime() bool { return false }
 

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -31,6 +31,9 @@ func (r *RTProcessCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 // Name returns the name of the RTProcessCheck.
 func (r *RTProcessCheck) Name() string { return "rtprocess" }
 
+// Endpoint returns the endpoint where this check is submitted.
+func (c *RTProcessCheck) Endpoint() string { return "/api/v1/collector" }
+
 // RealTime indicates if this check only runs in real-time mode.
 func (c *RTProcessCheck) RealTime() bool { return true }
 


### PR DESCRIPTION
So we can isolate the APIs and processing per message types if needed.