### PR TITLE
Improve allocations in AllContainers

### DIFF
--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -70,3 +70,12 @@ func TestContainerChunking(t *testing.T) {
 
 	}
 }
+
+func BenchmarkAllContainers(b *testing.B) {
+	docker.InitDockerUtil(true, true)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		docker.AllContainers()
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -2,10 +2,10 @@ package util
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // ErrNotImplemented is the "not implemented" error given by `gopsutil` when an
@@ -22,17 +22,11 @@ func ReadLines(filename string) ([]string, error) {
 	defer f.Close()
 
 	var ret []string
-
-	r := bufio.NewReader(f)
-	for {
-		line, err := r.ReadString('\n')
-		if err != nil {
-			break
-		}
-		ret = append(ret, strings.Trim(line, "\n"))
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		ret = append(ret, scanner.Text())
 	}
-
-	return ret, nil
+	return ret, scanner.Err()
 }
 
 // GetEnv retrieves the environment variable key. If it does not exist it returns the default.
@@ -48,10 +42,13 @@ func GetEnv(key string, dfault string, combineWith ...string) string {
 	case 1:
 		return filepath.Join(value, combineWith[0])
 	default:
-		all := make([]string, len(combineWith)+1)
-		all[0] = value
-		copy(all[1:], combineWith)
-		return filepath.Join(all...)
+		var b bytes.Buffer
+		b.WriteString(value)
+		for _, v := range combineWith {
+			b.WriteRune('/')
+			b.WriteString(v)
+		}
+		return b.String()
 	}
 }
 


### PR DESCRIPTION
This is a call we will make many times over in general but especially in
the containers-only state which will be on by default.

The main source of allocations is because we have to read through every
`/proc/$pid/cgroup` file to find all valid cgroups and processes in
cgroups. So we've switched to smarter file reading where possible, but
there's certainly more we can do.

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkAllContainers-2     4552072       3864796       -15.10%

benchmark                    old allocs     new allocs     delta
BenchmarkAllContainers-2     7571           2477           -67.28%
```