### PR TITLE
Add filtering for container name, image with k8s defaults.

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -142,7 +142,7 @@ func main() {
 }
 
 func initMetadataProviders(cfg *config.AgentConfig) {
-	if err := docker.InitDockerUtil(&docker.DockerConfig{
+	if err := docker.InitDockerUtil(&docker.Config{
 		CollectHealth:  cfg.CollectDockerHealth,
 		CollectNetwork: cfg.CollectDockerNetwork,
 		Whitelist:      cfg.ContainerWhitelist,
@@ -151,12 +151,15 @@ func initMetadataProviders(cfg *config.AgentConfig) {
 		log.Errorf("unable to initialize docker collection: %s", err)
 	}
 
-	err := kubernetes.InitKubeUtil(cfg.KubernetesKubeletHost, cfg.KubernetesHTTPKubeletPort, cfg.KubernetesHTTPSKubeletPort)
-	if err != nil && err != kubernetes.ErrKubernetesNotAvailable {
+	if err := kubernetes.InitKubeUtil(&kubernetes.Config{
+		KubeletHost:      cfg.KubernetesKubeletHost,
+		KubeletHTTPPort:  cfg.KubernetesHTTPKubeletPort,
+		KubeletHTTPSPort: cfg.KubernetesHTTPSKubeletPort,
+	}); err != nil && err != kubernetes.ErrKubernetesNotAvailable {
 		log.Errorf("unable to initialize kubernetes collection: %s", err)
 	}
 
-	err = ecs.InitECSUtil()
+	err := ecs.InitECSUtil()
 	if err != nil && err != ecs.ErrECSNotAvailable {
 		log.Errorf("unable to initialize ECS collection: %s", err)
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -142,12 +142,16 @@ func main() {
 }
 
 func initMetadataProviders(cfg *config.AgentConfig) {
-	err := docker.InitDockerUtil(cfg.CollectDockerHealth, cfg.CollectDockerNetwork)
-	if err != nil && err != docker.ErrDockerNotAvailable {
+	if err := docker.InitDockerUtil(&docker.DockerConfig{
+		CollectHealth:  cfg.CollectDockerHealth,
+		CollectNetwork: cfg.CollectDockerNetwork,
+		Whitelist:      cfg.ContainerWhitelist,
+		Blacklist:      cfg.ContainerBlacklist,
+	}); err != nil && err != docker.ErrDockerNotAvailable {
 		log.Errorf("unable to initialize docker collection: %s", err)
 	}
 
-	err = kubernetes.InitKubeUtil(cfg)
+	err := kubernetes.InitKubeUtil(cfg.KubernetesKubeletHost, cfg.KubernetesHTTPKubeletPort, cfg.KubernetesHTTPSKubeletPort)
 	if err != nil && err != kubernetes.ErrKubernetesNotAvailable {
 		log.Errorf("unable to initialize kubernetes collection: %s", err)
 	}

--- a/util/docker/docker.go
+++ b/util/docker/docker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -47,6 +48,97 @@ type NetworkStat struct {
 	PacketsRcvd uint64
 }
 
+type containerFilter struct {
+	Enabled        bool
+	ImageWhitelist []*regexp.Regexp
+	NameWhitelist  []*regexp.Regexp
+	ImageBlacklist []*regexp.Regexp
+	NameBlacklist  []*regexp.Regexp
+}
+
+// NewcontainerFilter creates a new container filter from a two slices of
+// regexp patterns for a whitelist and blacklist. Each pattern should have
+// the following format: "field:pattern" where field can be: [image, name].
+// An error is returned if any of the expression don't compile.
+func newContainerFilter(whitelist, blacklist []string) (*containerFilter, error) {
+	iwl, nwl, err := parseFilters(whitelist)
+	if err != nil {
+		return nil, err
+	}
+	ibl, nbl, err := parseFilters(blacklist)
+	if err != nil {
+		return nil, err
+	}
+
+	return &containerFilter{
+		Enabled:        len(whitelist) > 0 || len(blacklist) > 0,
+		ImageWhitelist: iwl,
+		NameWhitelist:  nwl,
+		ImageBlacklist: ibl,
+		NameBlacklist:  nbl,
+	}, nil
+}
+
+func parseFilters(filters []string) (imageFilters, nameFilters []*regexp.Regexp, err error) {
+	for _, filter := range filters {
+		switch {
+		case strings.HasPrefix(filter, "image:"):
+			pat := strings.TrimPrefix(filter, "image:")
+			r, err := regexp.Compile(strings.TrimPrefix(pat, "image:"))
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
+			}
+			imageFilters = append(imageFilters, r)
+		case strings.HasPrefix(filter, "name:"):
+			pat := strings.TrimPrefix(filter, "name:")
+			r, err := regexp.Compile(pat)
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid regex '%s': %s", pat, err)
+			}
+			nameFilters = append(nameFilters, r)
+		}
+	}
+	return imageFilters, nameFilters, nil
+}
+
+// IsExcluded returns a bool indicating if the container should be excluded
+// based on the filters in the containerFilter instance.
+func (cf containerFilter) IsExcluded(container *Container) bool {
+	if !cf.Enabled {
+		return false
+	}
+
+	var excluded bool
+	for _, r := range cf.ImageBlacklist {
+		if r.MatchString(container.Image) {
+			excluded = true
+			break
+		}
+	}
+	for _, r := range cf.NameBlacklist {
+		if r.MatchString(container.Name) {
+			excluded = true
+			break
+		}
+	}
+
+	// Any excluded container could be whitelisted.
+	if excluded {
+		for _, r := range cf.ImageWhitelist {
+			if r.MatchString(container.Image) {
+				return false
+			}
+		}
+		for _, r := range cf.NameWhitelist {
+			if r.MatchString(container.Name) {
+				return false
+			}
+		}
+	}
+
+	return excluded
+}
+
 type Container struct {
 	Type    string
 	ID      string
@@ -75,19 +167,34 @@ func (a dockerNetworks) Len() int           { return len(a) }
 func (a dockerNetworks) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a dockerNetworks) Less(i, j int) bool { return a[i].dockerName < a[j].dockerName }
 
+// DockerConfig is an exported configuration object that is used when
+// initializing the DockerUtil.
+type DockerConfig struct {
+	// CollectHealth enables health collection. This requires calling a
+	// container.Inspect for each container on every called to getContainers().
+	CollectHealth bool
+	// CollectNetwork enables network stats collection. This requires at least
+	// one call to container.Inspect for new containers and reads from the
+	// procfs for stats.
+	CollectNetwork bool
+	// Whitelist is a slice of filter strings in the form of key:regex where key
+	// is either 'image' or 'name' and regex is a valid regular expression.
+	Whitelist []string
+	// Blacklist is the same as whitelist but for exclusion.
+	Blacklist []string
+
+	// internal use only
+	filter *containerFilter
+}
+
 // dockerUtil wraps interactions with a local docker API.
 type dockerUtil struct {
+	cfg *DockerConfig
 	cli *client.Client
 	// tracks the last time we invalidate our internal caches
 	lastInvalidate time.Time
 	// networkMappings by container id
 	networkMappings map[string][]dockerNetwork
-	// if enabled we will collect health. this requires calling a container.Inspect
-	// for each container on every called to getContainers().
-	collectHealth bool
-	// if enabled we will collect network statistics. this requires at least one
-	// call to container.Inspect for new containers and reads from the procfs for stats.
-	collectNetwork bool
 	sync.Mutex
 }
 
@@ -134,9 +241,14 @@ func GetHostname() (string, error) {
 	return globalDockerUtil.getHostname()
 }
 
+// IsContainerized returns True if we're running in the docker-dd-agent container.
+func IsContainerized() bool {
+	return os.Getenv("DOCKER_DD_AGENT") == "true"
+}
+
 // InitDockerUtil initializes the global dockerUtil singleton. This _must_ be
 // called before accessing any of the top-level docker calls.
-func InitDockerUtil(collectHealth, collectNetwork bool) error {
+func InitDockerUtil(cfg *DockerConfig) error {
 	// If we don't have a docker.sock then return a known error.
 	sockPath := util.GetEnv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
 	if !util.PathExists(sockPath) {
@@ -160,12 +272,17 @@ func InitDockerUtil(collectHealth, collectNetwork bool) error {
 		return err
 	}
 
+	// Pre-parse the filter and use that internally.
+	cfg.filter, err = newContainerFilter(cfg.Whitelist, cfg.Blacklist)
+	if err != nil {
+		return err
+	}
+
 	globalDockerUtil = &dockerUtil{
+		cfg:             cfg,
 		cli:             cli,
 		networkMappings: make(map[string][]dockerNetwork),
 		lastInvalidate:  time.Now(),
-		collectHealth:   collectHealth,
-		collectNetwork:  collectNetwork,
 	}
 	return nil
 }
@@ -182,7 +299,7 @@ func (d *dockerUtil) getContainers() ([]*Container, error) {
 	for _, c := range containers {
 		var health string
 		var i types.ContainerJSON
-		if d.collectHealth {
+		if d.cfg.CollectHealth {
 			// We could have lost the container between list and inspect so ignore these errors.
 			i, err = d.cli.ContainerInspect(context.Background(), c.ID)
 			if err != nil && client.IsErrContainerNotFound(err) {
@@ -194,7 +311,7 @@ func (d *dockerUtil) getContainers() ([]*Container, error) {
 			}
 		}
 
-		if d.collectNetwork {
+		if d.cfg.CollectNetwork {
 			// FIXME: We might need to invalidate this cache if a containers networks are changed live.
 			d.Lock()
 			if _, ok := d.networkMappings[c.ID]; !ok {
@@ -210,7 +327,7 @@ func (d *dockerUtil) getContainers() ([]*Container, error) {
 			d.Unlock()
 		}
 
-		ret = append(ret, &Container{
+		container := &Container{
 			Type:    "Docker",
 			ID:      c.ID,
 			Name:    c.Names[0],
@@ -219,7 +336,10 @@ func (d *dockerUtil) getContainers() ([]*Container, error) {
 			Created: c.Created,
 			State:   c.State,
 			Health:  health,
-		})
+		}
+		if !d.cfg.filter.IsExcluded(container) {
+			ret = append(ret, container)
+		}
 	}
 
 	if d.lastInvalidate.Add(invalidationInterval).After(time.Now()) {
@@ -258,7 +378,7 @@ func (d *dockerUtil) containers(pids []int32) ([]*Container, error) {
 			return nil, err
 		}
 
-		if d.collectNetwork {
+		if d.cfg.CollectNetwork {
 			d.Lock()
 			networks, ok := d.networkMappings[cgroup.ContainerID]
 			d.Unlock()
@@ -269,7 +389,10 @@ func (d *dockerUtil) containers(pids []int32) ([]*Container, error) {
 				}
 				container.Network = netStat
 			}
+		} else {
+			container.Network = NullContainer.Network
 		}
+
 		container.Pids = cgroup.Pids
 	}
 	return containers, nil

--- a/util/docker/docker.go
+++ b/util/docker/docker.go
@@ -167,9 +167,9 @@ func (a dockerNetworks) Len() int           { return len(a) }
 func (a dockerNetworks) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a dockerNetworks) Less(i, j int) bool { return a[i].dockerName < a[j].dockerName }
 
-// DockerConfig is an exported configuration object that is used when
+// Config is an exported configuration object that is used when
 // initializing the DockerUtil.
-type DockerConfig struct {
+type Config struct {
 	// CollectHealth enables health collection. This requires calling a
 	// container.Inspect for each container on every called to getContainers().
 	CollectHealth bool
@@ -189,7 +189,7 @@ type DockerConfig struct {
 
 // dockerUtil wraps interactions with a local docker API.
 type dockerUtil struct {
-	cfg *DockerConfig
+	cfg *Config
 	cli *client.Client
 	// tracks the last time we invalidate our internal caches
 	lastInvalidate time.Time
@@ -248,7 +248,7 @@ func IsContainerized() bool {
 
 // InitDockerUtil initializes the global dockerUtil singleton. This _must_ be
 // called before accessing any of the top-level docker calls.
-func InitDockerUtil(cfg *DockerConfig) error {
+func InitDockerUtil(cfg *Config) error {
 	// If we don't have a docker.sock then return a known error.
 	sockPath := util.GetEnv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
 	if !util.PathExists(sockPath) {

--- a/util/docker/docker_test.go
+++ b/util/docker/docker_test.go
@@ -157,11 +157,11 @@ func detab(str string) string {
 
 // Sanity-check that all containers works with different settings.
 func TestAllContainers(t *testing.T) {
-	InitDockerUtil(&DockerConfig{CollectHealth: true, CollectNetwork: true})
+	InitDockerUtil(&Config{CollectHealth: true, CollectNetwork: true})
 	AllContainers()
-	InitDockerUtil(&DockerConfig{CollectHealth: false, CollectNetwork: true})
+	InitDockerUtil(&Config{CollectHealth: false, CollectNetwork: true})
 	AllContainers()
-	InitDockerUtil(&DockerConfig{CollectHealth: true, CollectNetwork: false})
+	InitDockerUtil(&Config{CollectHealth: true, CollectNetwork: false})
 	AllContainers()
 }
 

--- a/util/docker/docker_test.go
+++ b/util/docker/docker_test.go
@@ -157,10 +157,68 @@ func detab(str string) string {
 
 // Sanity-check that all containers works with different settings.
 func TestAllContainers(t *testing.T) {
-	InitDockerUtil(true, true)
+	InitDockerUtil(&DockerConfig{CollectHealth: true, CollectNetwork: true})
 	AllContainers()
-	InitDockerUtil(false, true)
+	InitDockerUtil(&DockerConfig{CollectHealth: false, CollectNetwork: true})
 	AllContainers()
-	InitDockerUtil(true, false)
+	InitDockerUtil(&DockerConfig{CollectHealth: true, CollectNetwork: false})
 	AllContainers()
+}
+
+func TestContainerFilter(t *testing.T) {
+	assert := assert.New(t)
+	containers := []*Container{
+		{ID: "1", Name: "secret-container-dd", Image: "docker-dd-agent"},
+		{ID: "2", Name: "webapp1-dd", Image: "apache:2.2"},
+		{ID: "3", Name: "mysql-dd", Image: "mysql:5.3"},
+		{ID: "4", Name: "linux-dd", Image: "alpine:latest"},
+		{ID: "5", Name: "k8s_POD.f8120f_kube-proxy-gke-pool-1-2890-pv0", Image: "gcr.io/google_containers/pause-amd64:3.0"},
+	}
+
+	for i, tc := range []struct {
+		whitelist   []string
+		blacklist   []string
+		expectedIDs []string
+	}{
+		{
+			expectedIDs: []string{"1", "2", "3", "4", "5"},
+		},
+		{
+			blacklist:   []string{"name:secret"},
+			expectedIDs: []string{"2", "3", "4", "5"},
+		},
+		{
+			blacklist:   []string{"image:secret"},
+			expectedIDs: []string{"1", "2", "3", "4", "5"},
+		},
+		{
+			whitelist:   []string{},
+			blacklist:   []string{"image:apache", "image:alpine"},
+			expectedIDs: []string{"1", "3", "5"},
+		},
+		{
+			whitelist:   []string{"name:mysql"},
+			blacklist:   []string{"name:dd"},
+			expectedIDs: []string{"3", "5"},
+		},
+		// Test kubernetes defaults
+		{
+			blacklist: []string{
+				"image:gcr.io/google_containers/pause.*",
+				"image:openshift/origin-pod",
+			},
+			expectedIDs: []string{"1", "2", "3", "4"},
+		},
+	} {
+		f, err := newContainerFilter(tc.whitelist, tc.blacklist)
+		assert.NoError(err, "case %d", i)
+
+		var allowed []string
+		for _, c := range containers {
+			if !f.IsExcluded(c) {
+				allowed = append(allowed, c.ID)
+			}
+		}
+		assert.Equal(tc.expectedIDs, allowed, "case %d", i)
+	}
 }


### PR DESCRIPTION
Generally matching the behavior of the Agent 5 dockerutil, we will
filter out containers on the image or name. Unforunately, unlike the
Agent 5, we don't have a full set of tags for every container so
filtering beyond this would require more surgery.

By default we will filter out the noisy containers from Kubernetes like
the "pause" container.