### PR TITLE
Enable containers by default if docker is available and connectable.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 	}
 	ac := &AgentConfig{
 		// We'll always run inside of a container.
-		Enabled:       docker.IsContainerized(),
+		Enabled:       docker.IsContainerized() || docker.IsAvailable(),
 		HostName:      hostname,
 		APIEndpoint:   u,
 		LogFile:       defaultLogFilePath,


### PR DESCRIPTION
This extends the existing default setting of always running when inside
the docker-dd-agent container. Now we will also collect containers if
the process can read from docker.sock even outside of a container.

Otherwise, without explicitly enabling the Agent, it will stop.