### PR TITLE
Allow override of ddagent py and ddagent python environment

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,7 +93,8 @@ func TestConfigNewIfExists(t *testing.T) {
 }
 
 func TestGetHostname(t *testing.T) {
-	h, err := getHostname()
+	cfg := NewDefaultAgentConfig()
+	h, err := getHostname(cfg.DDAgentPy, cfg.DDAgentPyEnv)
 	assert.Nil(t, err)
 	assert.NotEqual(t, "", h)
 }


### PR DESCRIPTION
For support unique environments such as cloudfoundry. In most cases these flags should never be used.