### PR TITLE
Fix DD_LOGS_STDOUT flag value to match docker-dd-agent

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -312,7 +312,7 @@ func mergeEnv(c *AgentConfig) *AgentConfig {
 	if v := os.Getenv("DD_LOG_LEVEL"); v != "" {
 		c.LogLevel = v
 	}
-	if v := os.Getenv("DD_LOGS_STDOUT"); v == "true" {
+	if v := os.Getenv("DD_LOGS_STDOUT"); v == "yes" {
 		// Empty log file implies logging to stdout and stdout
 		c.LogFile = ""
 	}


### PR DESCRIPTION
Should be `yes` not `true`: https://github.com/DataDog/docker-dd-agent#environment-variables