### PR TITLE
Convert all log levels to lower case

### DIFF
--- a/config/log.go
+++ b/config/log.go
@@ -296,7 +296,7 @@ func NewLoggerLevel(logLevel, logFile string) error {
 		console = true
 	}
 	loggerConfig := &LoggerConfig{
-		LogLevel:    logLevel,
+		LogLevel:    strings.ToLower(logLevel),
 		Filename:    logFile,
 		SyslogLevel: "off",
 		Console:     console,

--- a/config/log_test.go
+++ b/config/log_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLogLevelCase(t *testing.T) {
+	assert.NoError(t, NewLoggerLevel("DEBUG", defaultLogFilePath))
+	assert.NoError(t, NewLoggerLevel("debug", defaultLogFilePath))
+	assert.NoError(t, NewLoggerLevel("InFo", defaultLogFilePath))
+	assert.NoError(t, NewLoggerLevel("INFO", defaultLogFilePath))
+}


### PR DESCRIPTION
So we can support all varieties of casing and to match the upper-case format used by the infrastructure Agent.

Fixes a custom issue where they have `-e LOG_LEVEL=DEBUG` for the docker dd-agent