### PR TITLE
Only default Enabled if Docker socket is connectable.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 	}
 	ac := &AgentConfig{
 		// We'll always run inside of a container.
-		Enabled:       docker.IsContainerized() || docker.IsAvailable(),
+		Enabled:       docker.IsAvailable(),
 		APIEndpoint:   u,
 		LogFile:       defaultLogFilePath,
 		LogLevel:      "info",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -120,7 +120,7 @@ func TestDefaultConfig(t *testing.T) {
 
 	os.Setenv("DOCKER_DD_AGENT", "yes")
 	agentConfig = NewDefaultAgentConfig()
-	assert.Equal(agentConfig.Enabled, true)
+	assert.Equal(agentConfig.Enabled, false)
 	assert.Equal(os.Getenv("HOST_PROC"), "/host/proc")
 	assert.Equal(os.Getenv("HOST_SYS"), "/host/sys")
 	os.Setenv("DOCKER_DD_AGENT", "no")


### PR DESCRIPTION
There are cases where folks are running the containerized Agent but
don't mount the docker.sock file so we end up in a crash loop like:

```
2017-09-04 07:47:18 ERROR (ecs.go:26) - unable to configure ECS metada collection: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2017-09-04 07:47:20 ERROR (ecs.go:26) - unable to configure ECS metada collection: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2017-09-04 07:47:20 INFO (collector.go:106) - Starting process-agent for host=XXXX, endpoint=https://process.datadoghq.com
2017-09-04 07:47:22 ERROR (ecs.go:26) - unable to configure ECS metada collection: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2017-09-04 07:47:22 INFO (collector.go:106) - Starting process-agent for host=XXXX, endpoint=https://process.datadoghq.com
2017-09-04 07:47:26 ERROR (ecs.go:26) - unable to configure ECS metada collection: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2017-09-04 07:47:26 INFO (collector.go:106) - Starting process-agent for host=XXXX, endpoint=https://process.datadoghq.com
```
