### PR TITLE
If scheme is nil url.Parse will throw an error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -526,10 +526,21 @@ func constructProxy(host, scheme string, port int, user, password string) *url.U
 	}
 
 	var path string
-	if userpass != nil {
-		path = fmt.Sprintf("%s://%s@%s:%v", scheme, userpass.String(), host, port)
+	// scheme is occasionally passed in as nil
+	if scheme != nil {
+		if userpass != nil {
+			path = fmt.Sprintf("%s://%s@%s:%v", scheme, userpass.String(), host, port)
+		} else {
+			path = fmt.Sprintf("%s://%s:%v", scheme, host, port)
+		}
 	} else {
 		path = fmt.Sprintf("%s://%s:%v", scheme, host, port)
+		if userpass != nil {
+			path = fmt.Sprintf("%s@%s:%v", userpass.String(), host, port)
+		} else {
+			path = fmt.Sprintf("%s:%v", host, port)
+
+		}
 	}
 
 	u, err := url.Parse(path)


### PR DESCRIPTION
Although datadog-process-agent supports proxy urls like the following:
* example.com
* http://example.com

The scheme was passed in blank resulting in an error in parsing a url
like `://example.com`

Please see https://play.golang.org/p/PUug1jdGSh for an example of the
error we are experiencing.

I wanted to add some tests but this project is not buildable. There is another open issue regarding this problem https://github.com/DataDog/datadog-process-agent/issues/52 . Once corrected I am happy to add some tests.