### PR TITLE
Support proxy URLs without schemes, add test coverage on proxies.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,10 @@ import (
 )
 
 var (
+	// defaultProxyPort is the default port used for proxies.
+	// This mirrors the configuration for the infrastructure agent.
+	defaultProxyPort = 3128
+
 	processChecks   = []string{"process", "rtprocess"}
 	containerChecks = []string{"container", "rtcontainer"}
 
@@ -174,7 +178,11 @@ func NewAgentConfig(agentConf, legacyConf *File) (*AgentConfig, error) {
 		ak := strings.Split(a, ",")
 		cfg.APIKey = ak[0]
 		cfg.LogLevel = strings.ToLower(agentConf.GetDefault("Main", "log_level", "INFO"))
-		cfg.Proxy = getProxySettings(section)
+		cfg.Proxy, err = getProxySettings(section)
+		if err != nil {
+			log.Errorf("error parsing proxy settings, not using a proxy: %s", err)
+		}
+
 		e := agentConf.GetDefault(ns, "endpoint", defaultEndpoint)
 		u, err := url.Parse(e)
 		if err != nil {
@@ -296,6 +304,7 @@ func NewAgentConfig(agentConf, legacyConf *File) (*AgentConfig, error) {
 
 // mergeEnv applies overrides from environment variables to the trace agent configuration
 func mergeEnv(c *AgentConfig) *AgentConfig {
+	var err error
 	if v := os.Getenv("DD_PROCESS_AGENT_ENABLED"); v == "false" {
 		c.Enabled = false
 	} else if v == "true" {
@@ -338,7 +347,10 @@ func mergeEnv(c *AgentConfig) *AgentConfig {
 		c.LogFile = ""
 	}
 
-	c.Proxy = proxyFromEnv(c.Proxy)
+	if c.Proxy, err = proxyFromEnv(c.Proxy); err != nil {
+		log.Errorf("error parsing proxy settings, not using a proxy: %s", err)
+		c.Proxy = nil
+	}
 
 	if v := os.Getenv("DD_PROCESS_AGENT_URL"); v != "" {
 		u, err := url.Parse(v)
@@ -445,8 +457,9 @@ func getHostname(ddAgentPy string, ddAgentEnv []string) (string, error) {
 // getProxySettings returns a url.Url for the proxy configuration from datadog.conf, if available.
 // In the case of invalid settings an error is logged and nil is returned. If settings are missing,
 // meaning we don't want a proxy, then nil is returned with no error.
-func getProxySettings(m *ini.Section) *url.URL {
-	var host, scheme string
+func getProxySettings(m *ini.Section) (*url.URL, error) {
+	var host string
+	scheme := "http"
 	if v := m.Key("proxy_host").MustString(""); v != "" {
 		// accept either http://myproxy.com or myproxy.com
 		if i := strings.Index(v, "://"); i != -1 {
@@ -459,10 +472,10 @@ func getProxySettings(m *ini.Section) *url.URL {
 	}
 
 	if host == "" {
-		return nil
+		return nil, nil
 	}
 
-	var port int
+	port := defaultProxyPort
 	if v := m.Key("proxy_port").MustInt(-1); v != -1 {
 		port = v
 	}
@@ -480,8 +493,9 @@ func getProxySettings(m *ini.Section) *url.URL {
 // similar way to getProxySettings and, if enough values are available, returns
 // a new proxy URL value. If the environment is not set for this then the
 // `defaultVal` is returned.
-func proxyFromEnv(defaultVal *url.URL) *url.URL {
-	var host, scheme string
+func proxyFromEnv(defaultVal *url.URL) (*url.URL, error) {
+	var host string
+	scheme := "http"
 	if v := os.Getenv("PROXY_HOST"); v != "" {
 		// accept either http://myproxy.com or myproxy.com
 		if i := strings.Index(v, "://"); i != -1 {
@@ -494,10 +508,10 @@ func proxyFromEnv(defaultVal *url.URL) *url.URL {
 	}
 
 	if host == "" {
-		return defaultVal
+		return defaultVal, nil
 	}
 
-	var port int
+	port := defaultProxyPort
 	if v := os.Getenv("PROXY_PORT"); v != "" {
 		port, _ = strconv.Atoi(v)
 	}
@@ -515,7 +529,7 @@ func proxyFromEnv(defaultVal *url.URL) *url.URL {
 // constructProxy constructs a *url.Url for a proxy given the parts of a
 // Note that we assume we have at least a non-empty host for this call but
 // all other values can be their defaults (empty string or 0).
-func constructProxy(host, scheme string, port int, user, password string) *url.URL {
+func constructProxy(host, scheme string, port int, user, password string) (*url.URL, error) {
 	var userpass *url.Userinfo
 	if user != "" {
 		if password != "" {
@@ -527,15 +541,13 @@ func constructProxy(host, scheme string, port int, user, password string) *url.U
 
 	var path string
 	if userpass != nil {
-		path = fmt.Sprintf("%s://%s@%s:%v", scheme, userpass.String(), host, port)
+		path = fmt.Sprintf("%s@%s:%v", userpass.String(), host, port)
 	} else {
-		path = fmt.Sprintf("%s://%s:%v", scheme, host, port)
+		path = fmt.Sprintf("%s:%v", host, port)
+	}
+	if scheme != "" {
+		path = fmt.Sprintf("%s://%s", scheme, path)
 	}
 
-	u, err := url.Parse(path)
-	if err != nil {
-		log.Errorf("error parsing proxy settings, not using a proxy: %s", err)
-		return nil
-	}
-	return u
+	return url.Parse(path)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -177,4 +178,153 @@ func TestDDAgentConfigWithNewOpts(t *testing.T) {
 	assert.Equal(false, agentConfig.AllowRealTime)
 	assert.Equal(false, agentConfig.Enabled)
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
+}
+
+func TestProxyEnv(t *testing.T) {
+	assert := assert.New(t)
+	var defaultVal *url.URL
+	for i, tc := range []struct {
+		host     string
+		port     int
+		user     string
+		pass     string
+		expected string
+	}{
+		{
+			"example.com",
+			1234,
+			"",
+			"",
+			"http://example.com:1234",
+		},
+		{
+			"https://example.com",
+			4567,
+			"foo",
+			"bar",
+			"https://foo:bar@example.com:4567",
+		},
+		{
+			"example.com",
+			0,
+			"foo",
+			"",
+			"http://foo@example.com:3128",
+		},
+	} {
+		os.Setenv("PROXY_HOST", tc.host)
+		if tc.port > 0 {
+			os.Setenv("PROXY_PORT", strconv.Itoa(tc.port))
+		} else {
+			os.Setenv("PROXY_PORT", "")
+		}
+		os.Setenv("PROXY_USER", tc.user)
+		os.Setenv("PROXY_PASSWORD", tc.pass)
+		u, err := proxyFromEnv(defaultVal)
+		assert.NoError(err, "proxy case %d had error", i)
+		assert.Equal(tc.expected, u.String())
+	}
+}
+
+func getURL(f *ini.File) (*url.URL, error) {
+	conf := File{
+		f,
+		"some/path",
+	}
+	m, _ := conf.GetSection("Main")
+	return getProxySettings(m)
+}
+
+func TestGetProxySettings(t *testing.T) {
+	assert := assert.New(t)
+
+	f, _ := ini.Load([]byte("[Main]\n\nproxy_host = myhost"))
+
+	s, err := getURL(f)
+	assert.NoError(err)
+	assert.Equal("http://myhost:3128", s.String())
+
+	f, _ = ini.Load([]byte("[Main]\n\nproxy_host = http://myhost"))
+
+	s, err = getURL(f)
+	assert.NoError(err)
+	assert.Equal("http://myhost:3128", s.String())
+
+	f, _ = ini.Load([]byte("[Main]\n\nproxy_host = https://myhost"))
+
+	s, err = getURL(f)
+	assert.NoError(err)
+	assert.Equal("https://myhost:3128", s.String())
+
+	// generic user name
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = https://myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.NoError(err)
+
+	assert.Equal("https://aaditya@myhost:3129", s.String())
+
+	// special char in user name <3
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = myhost",
+		"proxy_port = 3129",
+		"proxy_user = léo",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.NoError(err)
+
+	// user is url-encoded and decodes to original string
+	assert.Equal("http://l%C3%A9o@myhost:3129", s.String())
+	assert.Equal("léo", s.User.Username())
+
+	// generic  user-pass
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+		"proxy_password = password_12",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.NoError(err)
+	assert.Equal("http://aaditya:password_12@myhost:3129", s.String())
+
+	// user-pass with schemed host
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = https://myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+		"proxy_password = password_12",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.NoError(err)
+	assert.Equal("https://aaditya:password_12@myhost:3129", s.String())
+
+	// special characters in password
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = https://myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+		"proxy_password = /:!?&=@éÔγλῶσσα",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.NoError(err)
+
+	// password is url-encoded and decodes to the original string
+	assert.Equal("https://aaditya:%2F%3A%21%3F&=%40%C3%A9%C3%94%CE%B3%CE%BB%E1%BF%B6%CF%83%CF%83%CE%B1@myhost:3129", s.String())
+
+	pass, _ := s.User.Password()
+	assert.Equal("/:!?&=@éÔγλῶσσα", pass)
 }


### PR DESCRIPTION
A proxy URL without a scheme would throw an error despite the code saying that this was supported. This is fixed and lots of test coverage is added, matching the trace-agent.

Fixes #61 