### PR TITLE
[packaging] Update build scripts to use Go 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dd-process-agent -config $PATH_TO_PROCESS_CONFIG_FILE
 
 Pre-requisites:
 
-* `go >= 1.8.3`
+* `go >= 1.9.1`
 * `rake`
 
 Check out the repo in your `$GOPATH`

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -29,4 +29,4 @@ RUN wget http://www.musl-libc.org/releases/musl-1.1.10.tar.gz && \
 
 ENV GOPATH=/go
 ENV PATH=/go/bin:$PATH
-RUN gimme 1.8.3
+RUN gimme 1.9.1

--- a/packaging/build_ddagent_release.sh
+++ b/packaging/build_ddagent_release.sh
@@ -25,7 +25,7 @@ fi
 echo "Building Agent v$PROCESS_AGENT_VERSION to $FILENAME"
 
 # Expects gimme to be installed
-eval "$(gimme 1.8.3)"
+eval "$(gimme 1.9.1)"
 
 export GOPATH=$WORKSPACE/go
 export PATH=$PATH:$GOPATH/bin

--- a/packaging/build_release_package.sh
+++ b/packaging/build_release_package.sh
@@ -18,7 +18,7 @@ gpg -K
 cd $WORKSPACE/go/src/github.com/DataDog/datadog-process-agent/packaging
 
 # Expects gimme to be installed
-eval "$(gimme 1.8.3)"
+eval "$(gimme 1.9.1)"
 
 export GOPATH=$WORKSPACE/go
 export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
The latest version, including a `go get` security fix.