### PR TITLE
[docker] Handle other cgroup mounts style in parser

### DIFF
--- a/util/docker/cgroup.go
+++ b/util/docker/cgroup.go
@@ -376,8 +376,8 @@ func parseCgroupMountPoints(r io.Reader) map[string]string {
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		mount := scanner.Text()
-		if strings.HasPrefix(mount, "cgroup ") {
-			tokens := strings.Split(mount, " ")
+		tokens := strings.Split(mount, " ")
+		if len(tokens) >= 3 && tokens[2] == "cgroup" {
 			cgroupPath := tokens[1]
 
 			// Re-point /sys cgroups to /proc/sys

--- a/util/docker/cgroup_test.go
+++ b/util/docker/cgroup_test.go
@@ -44,6 +44,100 @@ func TestParseCgroupMountPoints(t *testing.T) {
 	}
 }
 
+// A variation on TestParseCgroupMountPoints using more realistic data.
+func TestParseCgroupMountPointsAlt(t *testing.T) {
+	for _, tc := range []struct {
+		contents []string
+		expected map[string]string
+	}{
+		{
+			contents: []string{
+				"proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0 ",
+				"tmpfs /dev tmpfs rw,nosuid,mode=755 0 0 ",
+				"devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666 0 0 ",
+				"sysfs /sys sysfs ro,nosuid,nodev,noexec,relatime 0 0 ",
+				"tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,relatime,mode=755 0 0 ",
+				"openrc /sys/fs/cgroup/openrc cgroup ro,nosuid,nodev,noexec,relatime,release_agent=/lib/rc/sh/cgroup-release-agent.sh,name=openrc 0 0 ",
+				"cpuset /sys/fs/cgroup/cpuset cgroup ro,nosuid,nodev,noexec,relatime,cpuset 0 0 ",
+				"cpu /sys/fs/cgroup/cpu cgroup ro,nosuid,nodev,noexec,relatime,cpu 0 0 ",
+				"cpuacct /sys/fs/cgroup/cpuacct cgroup ro,nosuid,nodev,noexec,relatime,cpuacct 0 0 ",
+				"blkio /sys/fs/cgroup/blkio cgroup ro,nosuid,nodev,noexec,relatime,blkio 0 0 ",
+				"memory /sys/fs/cgroup/memory cgroup ro,nosuid,nodev,noexec,relatime,memory 0 0 ",
+				"devices /sys/fs/cgroup/devices cgroup ro,nosuid,nodev,noexec,relatime,devices 0 0 ",
+				"freezer /sys/fs/cgroup/freezer cgroup ro,nosuid,nodev,noexec,relatime,freezer 0 0 ",
+				"net_cls /sys/fs/cgroup/net_cls cgroup ro,nosuid,nodev,noexec,relatime,net_cls 0 0 ",
+				"perf_event /sys/fs/cgroup/perf_event cgroup ro,nosuid,nodev,noexec,relatime,perf_event 0 0 ",
+				"net_prio /sys/fs/cgroup/net_prio cgroup ro,nosuid,nodev,noexec,relatime,net_prio 0 0 ",
+				"hugetlb /sys/fs/cgroup/hugetlb cgroup ro,nosuid,nodev,noexec,relatime,hugetlb 0 0 ",
+				"pids /sys/fs/cgroup/pids cgroup ro,nosuid,nodev,noexec,relatime,pids 0 0 ",
+				"cgroup /sys/fs/cgroup/systemd cgroup ro,nosuid,nodev,noexec,relatime,name=systemd 0 0 ",
+				"mqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0 ",
+				"/dev/xvdb1 /conf.d ext4 rw,relatime,data=ordered 0 0 ",
+				"/dev/xvdb1 /checks.d ext4 rw,relatime,data=ordered 0 0 ",
+				"proc /host/proc proc ro,relatime 0 0 ",
+				"xenfs /host/proc/xen xenfs rw,nosuid,nodev,noexec,relatime 0 0 ",
+				"binfmt_misc /host/proc/sys/fs/binfmt_misc binfmt_misc rw,nosuid,nodev,noexec,relatime 0 0 ",
+				"/dev/xvdb1 /etc/resolv.conf ext4 rw,relatime,data=ordered 0 0 ",
+				"/dev/xvdb1 /etc/hostname ext4 rw,relatime,data=ordered 0 0 ",
+				"/dev/xvdb1 /etc/hosts ext4 rw,relatime,data=ordered 0 0 ",
+				"shm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k 0 0 ",
+				"tmpfs /run/docker.sock tmpfs rw,nosuid,nodev,noexec,relatime,size=404072k,mode=755 0 0 ",
+				"cgroup_root /host/sys/fs/cgroup tmpfs ro,relatime,size=10240k,mode=755 0 0 ",
+				"openrc /host/sys/fs/cgroup/openrc cgroup rw,nosuid,nodev,noexec,relatime,release_agent=/lib/rc/sh/cgroup-release-agent.sh,name=openrc 0 0 ",
+				"cpuset /host/sys/fs/cgroup/cpuset cgroup rw,nosuid,nodev,noexec,relatime,cpuset 0 0 ",
+				"cpu /host/sys/fs/cgroup/cpu cgroup rw,nosuid,nodev,noexec,relatime,cpu 0 0 ",
+				"cpuacct /host/sys/fs/cgroup/cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpuacct 0 0 ",
+				"blkio /host/sys/fs/cgroup/blkio cgroup rw,nosuid,nodev,noexec,relatime,blkio 0 0 ",
+				"memory /host/sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0 ",
+				"devices /host/sys/fs/cgroup/devices cgroup rw,nosuid,nodev,noexec,relatime,devices 0 0 ",
+				"freezer /host/sys/fs/cgroup/freezer cgroup rw,nosuid,nodev,noexec,relatime,freezer 0 0 ",
+				"net_cls /host/sys/fs/cgroup/net_cls cgroup rw,nosuid,nodev,noexec,relatime,net_cls 0 0 ",
+				"perf_event /host/sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_event 0 0 ",
+				"net_prio /host/sys/fs/cgroup/net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_prio 0 0 ",
+				"hugetlb /host/sys/fs/cgroup/hugetlb cgroup rw,nosuid,nodev,noexec,relatime,hugetlb 0 0 ",
+				"pids /host/sys/fs/cgroup/pids cgroup rw,nosuid,nodev,noexec,relatime,pids 0 0 ",
+				"cgroup /host/sys/fs/cgroup/systemd cgroup rw,relatime,name=systemd 0 0 ",
+				"proc /proc/bus proc ro,relatime 0 0 ",
+				"proc /proc/fs proc ro,relatime 0 0 ",
+				"proc /proc/irq proc ro,relatime 0 0 ",
+				"proc /proc/sys proc ro,relatime 0 0 ",
+				"proc /proc/sysrq-trigger proc ro,relatime 0 0 ",
+				"tmpfs /proc/kcore tmpfs rw,nosuid,mode=755 0 0 ",
+				"tmpfs /proc/timer_list tmpfs rw,nosuid,mode=755 0 0 ",
+				"tmpfs /proc/sched_debug tmpfs rw,nosuid,mode=755 0 0 ",
+				"tmpfs /sys/firmware tmpfs ro,relatime 0 0",
+			},
+			expected: map[string]string{
+				"cpuset":     "/host/sys/fs/cgroup/cpuset",
+				"cpu":        "/host/sys/fs/cgroup/cpu",
+				"cpuacct":    "/host/sys/fs/cgroup/cpuacct",
+				"devices":    "/host/sys/fs/cgroup/devices",
+				"perf_event": "/host/sys/fs/cgroup/perf_event",
+				"hugetlb":    "/host/sys/fs/cgroup/hugetlb",
+				"blkio":      "/host/sys/fs/cgroup/blkio",
+				"freezer":    "/host/sys/fs/cgroup/freezer",
+				"memory":     "/host/sys/fs/cgroup/memory",
+				"net_cls":    "/host/sys/fs/cgroup/net_cls",
+				"net_prio":   "/host/sys/fs/cgroup/net_prio",
+				"openrc":     "/host/sys/fs/cgroup/openrc",
+				"pids":       "/host/sys/fs/cgroup/pids",
+				"systemd":    "/host/sys/fs/cgroup/systemd",
+			},
+		},
+		{
+			contents: []string{
+				"",
+				"",
+				"",
+			},
+			expected: map[string]string{},
+		},
+	} {
+		contents := strings.NewReader(strings.Join(tc.contents, "\n"))
+		assert.Equal(t, tc.expected, parseCgroupMountPoints(contents))
+	}
+}
+
 func TestParseCgroupPaths(t *testing.T) {
 	for _, tc := range []struct {
 		contents          []string


### PR DESCRIPTION
Reported by a customer: https://trello.com/c/sS3k74hq/593-agent-cant-find-cgroup-files

