### PR TITLE
Fix multi-core container CPU calculation

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -164,13 +164,5 @@ func calculateCtrPct(cur, prev uint64, numCPU int, before time.Time) float32 {
 	if before.IsZero() || diff <= 0 {
 		return 0
 	}
-
-	overalPct := float32(cur-prev) / float32(diff)
-	// Sometimes we get values that don't make sense, so we clamp to 100%
-	if overalPct > 100 {
-		overalPct = 100
-	}
-
-	// In order to emulate top we multiply utilization by # of CPUs so a busy loop would be 100%.
-	return overalPct * float32(numCPU)
+	return float32(cur-prev) / float32(diff)
 }


### PR DESCRIPTION
Unlike in process CPU collection, CPU timings in cgroups account for
multiple cores so values > 100 are totally valid. This fix makes the CPU
collection accurate for multi-core CPU containers.