### PR TITLE
Set StatsdHost default to "127.0.0.1" instead of "localhost"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,7 +110,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		AllowRealTime: true,
 
 		// Statsd for internal instrumentation
-		StatsdHost: "localhost",
+		StatsdHost: "127.0.0.1",
 		StatsdPort: 8125,
 
 		// Path and environment for the dd-agent embedded python


### PR DESCRIPTION
Localhost will sometimes resolve the IPv6 version :::1 which can cause trouble for some hosts. Using 127.0.0.1 should work consistently.