### PR TITLE
Move checks logging to debug, limit info logging.

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -91,7 +91,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	c.lastRun = time.Now()
 
 	statsd.Client.Gauge("datadog.process.containers.host_count", totalContainers, []string{}, 1)
-	log.Infof("collected containers in %s", time.Now().Sub(start))
+	log.Debugf("collected containers in %s", time.Now().Sub(start))
 	return messages, nil
 }
 

--- a/checks/process.go
+++ b/checks/process.go
@@ -116,7 +116,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 
 	statsd.Client.Gauge("datadog.process.containers.host_count", totalProcs, []string{}, 1)
 	statsd.Client.Gauge("datadog.process.processes.host_count", totalContainers, []string{}, 1)
-	log.Infof("collected processes in %s", time.Now().Sub(start))
+	log.Debugf("collected processes in %s", time.Now().Sub(start))
 	return messages, nil
 }
 


### PR DESCRIPTION
- Checks log their durations to debug level now.
- We will log the first 5 runs and then every 20 after that.
- Log enabled checks at start so we still know what's running in INFO level.

Fixes #75