### PR TITLE
Use new container api from datadog-agent

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -175,12 +175,7 @@ func main() {
 }
 
 func initMetadataProviders(cfg *config.AgentConfig) {
-	if err := docker.InitDockerUtil(&docker.Config{
-		CacheDuration:  cfg.ContainerCacheDuration,
-		CollectNetwork: cfg.CollectDockerNetwork,
-		Whitelist:      cfg.ContainerWhitelist,
-		Blacklist:      cfg.ContainerBlacklist,
-	}); err != nil && err != docker.ErrDockerNotAvailable {
+	if _, err := docker.GetDockerUtil(); err != nil && err != docker.ErrDockerNotAvailable {
 		log.Errorf("unable to initialize docker collection: %s", err)
 	}
 

--- a/checks/container.go
+++ b/checks/container.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/gopsutil/cpu"
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -48,7 +49,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DataDog/gopsutil/cpu"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -42,7 +43,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/checks/process.go
+++ b/checks/process.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/gopsutil/process"
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -63,7 +64,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -53,7 +54,7 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/util"
 	"github.com/DataDog/datadog-process-agent/util/kubernetes"
@@ -101,7 +102,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 	}
 	ac := &AgentConfig{
 		// We'll always run inside of a container.
-		Enabled:       docker.IsAvailable(),
+		Enabled:       container.IsAvailable(),
 		APIEndpoint:   u,
 		LogFile:       defaultLogFilePath,
 		LogLevel:      "info",

--- a/glide.lock
+++ b/glide.lock
@@ -8,7 +8,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 35417d1ab859d84edecd06ef2244b821295f9357
+  version: 72e88e7b414daa531bf246db6b52abc7324a4bf5
   repo: git@github.com:DataDog/datadog-agent.git
   vcs: git
   subpackages:

--- a/util/kubernetes/kubernetes.go
+++ b/util/kubernetes/kubernetes.go
@@ -275,9 +275,13 @@ func locateKubelet(cfg *Config) (string, error) {
 	var err error
 	hostname := cfg.KubeletHost
 	if cfg.KubeletHost == "" {
-		hostname, err = docker.GetHostname()
+		du, err := docker.GetDockerUtil()
 		if err != nil {
-			return "", fmt.Errorf("Unable to get hostname from docker: %s", err)
+			return "", fmt.Errorf("unable to get hostname from docker: %s", err)
+		}
+		hostname, err = du.GetHostname()
+		if err != nil {
+			return "", fmt.Errorf("unable to get hostname from docker: %s", err)
 		}
 	}
 


### PR DESCRIPTION
# What does this PR do?

- bump datadog-agent dependency to use the latest version of DockerUtil
- use the new container API to also get ecs container