### PR TITLE
Support new ECS API for Fargate support

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -175,12 +175,7 @@ func main() {
 }
 
 func initMetadataProviders(cfg *config.AgentConfig) {
-	if err := docker.InitDockerUtil(&docker.Config{
-		CacheDuration:  cfg.ContainerCacheDuration,
-		CollectNetwork: cfg.CollectDockerNetwork,
-		Whitelist:      cfg.ContainerWhitelist,
-		Blacklist:      cfg.ContainerBlacklist,
-	}); err != nil && err != docker.ErrDockerNotAvailable {
+	if _, err := docker.GetDockerUtil(); err != nil && err != docker.ErrDockerNotAvailable {
 		log.Errorf("unable to initialize docker collection: %s", err)
 	}
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -99,7 +99,9 @@ func main() {
 		log.Criticalf("Error reading datadog.yaml: %s", err)
 		os.Exit(1)
 	}
-
+	if yamlConf != nil {
+		config.SetupDDAgentConfig(opts.configPath)
+	}
 	cfg, err := config.NewAgentConfig(agentConf, yamlConf)
 	if err != nil {
 		log.Criticalf("Error parsing config: %s", err)

--- a/checks/container.go
+++ b/checks/container.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/gopsutil/cpu"
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -48,7 +49,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -97,11 +97,12 @@ func fmtContainerStats(
 		ifStats := ctr.Network.SumInterfaces()
 		lastIfStats := lastCtr.Network.SumInterfaces()
 		cpus := runtime.NumCPU()
+		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 		chunk = append(chunk, &model.ContainerStat{
 			Id:         ctr.ID,
-			UserPct:    calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, cpus, lastRun),
-			SystemPct:  calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, cpus, lastRun),
-			TotalPct:   calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, cpus, lastRun),
+			UserPct:    calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, lastRun),
+			SystemPct:  calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, lastRun),
+			TotalPct:   calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, lastRun),
 			CpuLimit:   float32(ctr.CPULimit),
 			MemRss:     ctr.Memory.RSS,
 			MemCache:   ctr.Memory.Cache,

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DataDog/gopsutil/cpu"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -42,7 +43,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
-	"github.com/DataDog/gopsutil/cpu"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +24,6 @@ func TestContainerChunking(t *testing.T) {
 		makeContainer("bim"),
 	}
 	lastRun := time.Now().Add(-5 * time.Second)
-	syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
 
 	for i, tc := range []struct {
 		cur, last []*docker.Container

--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -51,7 +51,7 @@ func TestContainerChunking(t *testing.T) {
 			expected: 2,
 		},
 	} {
-		chunked := fmtContainers(tc.cur, tc.last, syst2, syst1, lastRun, tc.chunks)
+		chunked := fmtContainers(tc.cur, tc.last, lastRun, tc.chunks)
 		assert.Len(t, chunked, tc.chunks, "len test %d", i)
 		total := 0
 		for _, c := range chunked {
@@ -59,7 +59,7 @@ func TestContainerChunking(t *testing.T) {
 		}
 		assert.Equal(t, tc.expected, total, "total test %d", i)
 
-		chunkedStat := fmtContainerStats(tc.cur, tc.last, syst2, syst1, lastRun, tc.chunks)
+		chunkedStat := fmtContainerStats(tc.cur, tc.last, lastRun, tc.chunks)
 		assert.Len(t, chunkedStat, tc.chunks, "len stat test %d", i)
 		total = 0
 		for _, c := range chunked {
@@ -67,17 +67,5 @@ func TestContainerChunking(t *testing.T) {
 		}
 		assert.Equal(t, tc.expected, total, "total test %d", i)
 
-	}
-}
-
-func BenchmarkAllContainers(b *testing.B) {
-	docker.InitDockerUtil(&docker.Config{
-		CacheDuration:  10 * time.Second,
-		CollectNetwork: true,
-	})
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		docker.AllContainers(&docker.ContainerListConfig{})
 	}
 }

--- a/checks/process.go
+++ b/checks/process.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/gopsutil/process"
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -63,7 +64,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/checks/process.go
+++ b/checks/process.go
@@ -89,8 +89,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 		return nil, nil
 	}
 	groupSize := len(chunkedProcs)
-	chunkedContainers := fmtContainers(containers, p.lastContainers,
-		cpuTimes[0], p.lastCPUTime, p.lastRun, groupSize)
+	chunkedContainers := fmtContainers(containers, p.lastContainers, p.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	totalProcs, totalContainers := float64(0), float64(0)
 	for i := 0; i < groupSize; i++ {

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
@@ -53,7 +54,7 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if err != nil {
 		return nil, err
 	}
-	containers, err := docker.AllContainers(&docker.ContainerListConfig{})
+	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
 		return nil, err
 	}

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -71,8 +71,7 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	chunkedStats := fmtProcessStats(cfg, procs, r.lastProcs,
 		containers, cpuTimes[0], r.lastCPUTime, r.lastRun)
 	groupSize := len(chunkedStats)
-	chunkedCtrStats := fmtContainerStats(containers, r.lastContainers,
-		cpuTimes[0], r.lastCPUTime, r.lastRun, groupSize)
+	chunkedCtrStats := fmtContainerStats(containers, r.lastContainers, r.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	for i := 0; i < groupSize; i++ {
 		messages = append(messages, &model.CollectorRealTime{

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/util"
 	"github.com/DataDog/datadog-process-agent/util/kubernetes"
@@ -101,7 +102,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 	}
 	ac := &AgentConfig{
 		// We'll always run inside of a container.
-		Enabled:       docker.IsAvailable(),
+		Enabled:       container.IsAvailable(),
 		APIEndpoint:   u,
 		LogFile:       defaultLogFilePath,
 		LogLevel:      "info",

--- a/config/config.go
+++ b/config/config.go
@@ -414,7 +414,11 @@ func getHostname(ddAgentPy, ddAgentBin string, ddAgentEnv []string) (string, err
 	}
 
 	dockerEnv := os.Getenv("DOCKER_DD_AGENT")
-	cmd.Env = append(ddAgentEnv, fmt.Sprintf("DOCKER_DD_AGENT=%s", dockerEnv))
+	hostnameEnv := os.Getenv("DD_HOSTNAME")
+	cmd.Env = append(ddAgentEnv,
+		fmt.Sprintf("DOCKER_DD_AGENT=%s", dockerEnv),
+		fmt.Sprintf("DD_HOSTNAME=%s", hostnameEnv),
+	)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/config/config.go
+++ b/config/config.go
@@ -140,7 +140,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 	}
 
 	// Set default values for proc/sys paths if unset.
-	// Don't set this is /host is not mounted to use context wihin container.
+	// Don't set this is /host is not mounted to use context within container.
+	// Generally only applicable for container-only cases like Fargate.
 	if docker.IsContainerized() && util.PathExists("/host") {
 		if v := os.Getenv("HOST_PROC"); v == "" {
 			os.Setenv("HOST_PROC", "/host/proc")

--- a/config/config.go
+++ b/config/config.go
@@ -140,7 +140,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 	}
 
 	// Set default values for proc/sys paths if unset.
-	if docker.IsContainerized() {
+	// Don't set this is /host is not mounted to use context wihin container.
+	if docker.IsContainerized() && util.PathExists("/host") {
 		if v := os.Getenv("HOST_PROC"); v == "" {
 			os.Setenv("HOST_PROC", "/host/proc")
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,8 +124,8 @@ func TestDefaultConfig(t *testing.T) {
 	os.Setenv("DOCKER_DD_AGENT", "yes")
 	agentConfig = NewDefaultAgentConfig()
 	assert.Equal(agentConfig.Enabled, false)
-	assert.Equal(os.Getenv("HOST_PROC"), "/host/proc")
-	assert.Equal(os.Getenv("HOST_SYS"), "/host/sys")
+	assert.Equal(os.Getenv("HOST_PROC"), "")
+	assert.Equal(os.Getenv("HOST_SYS"), "")
 	os.Setenv("DOCKER_DD_AGENT", "no")
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 }

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	log "github.com/cihub/seelog"
 	"gopkg.in/yaml.v2"
 
@@ -134,4 +135,21 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 		agentConf.DDAgentBin = yc.Process.DDAgentBin
 	}
 	return agentConf, nil
+}
+
+// SetupDDAgentConfig initializes the datadog-agent config with a YAML file.
+// This is required for configuration to be available for container listeners.
+func SetupDDAgentConfig(configPath string) error {
+	ddconfig.Datadog.AddConfigPath(configPath)
+	// If they set a config file directly, let's try to honor that
+	if strings.HasSuffix(configPath, ".yaml") {
+		ddconfig.Datadog.SetConfigFile(configPath)
+	}
+
+	// load the configuration
+	err := ddconfig.Datadog.ReadInConfig()
+	if err != nil {
+		return fmt.Errorf("unable to load Datadog config file: %s", err)
+	}
+	return nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -8,7 +8,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 35417d1ab859d84edecd06ef2244b821295f9357
+  version: 72e88e7b414daa531bf246db6b52abc7324a4bf5
   repo: git@github.com:DataDog/datadog-agent.git
   vcs: git
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -8,7 +8,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 72e88e7b414daa531bf246db6b52abc7324a4bf5
+  version: a1a945b5c4cbf64ee2762a71c25d6229c57a4840
   repo: git@github.com:DataDog/datadog-agent.git
   vcs: git
   subpackages:

--- a/util/ecs/ecs.go
+++ b/util/ecs/ecs.go
@@ -61,6 +61,8 @@ type ecsUtil struct {
 	metadataSource string
 }
 
+// getMetadata will fetch the ECS metadata from either ecs-agent running in a separate
+// container or a local API when we're running in Fargate.
 func (e *ecsUtil) getMetadata() *agentpayload.ECSMetadataPayload {
 	switch e.metadataSource {
 	case "agent":

--- a/util/ecs/ecs.go
+++ b/util/ecs/ecs.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 
 	agentpayload "github.com/DataDog/agent-payload/gogen"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	agentecs "github.com/DataDog/datadog-agent/pkg/metadata/ecs"
-	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 	log "github.com/cihub/seelog"
 )
 
@@ -19,16 +20,32 @@ var (
 
 // InitECSUtil initializes a global ecsUtil used by later function calls.
 func InitECSUtil() error {
-	_, err := agentecs.GetPayload()
-	if err != nil {
-		if !ecsutil.IsAgentNotDetected(err) {
-			log.Errorf("unable to configure ECS metada collection: %s", err)
+	// If we have an ECS listener then we'll use the local API
+	var listeners []ddconfig.Listeners
+	if err := ddconfig.Datadog.UnmarshalKey("listeners", &listeners); err != nil {
+		log.Warnf("unable to parse listeners from the datadog config: %s", err)
+	} else {
+		for _, l := range listeners {
+			if l.Name == "ecs" {
+				globalECSUtil = &ecsUtil{metadataSource: "api"}
+				return nil
+			}
 		}
-		return ErrECSNotAvailable
 	}
 
-	globalECSUtil = &ecsUtil{}
-	return nil
+	// Otherwise let's try to find a local ECS-agent
+	_, err := agentecs.GetPayload()
+	if err == nil {
+		globalECSUtil = &ecsUtil{metadataSource: "agent"}
+		return nil
+	}
+
+	if !ecs.IsAgentNotDetected(err) {
+		log.Errorf("unable to configure ECS metada collection: %s", err)
+	}
+
+	// If we don't succeed in either case return a known error.
+	return ErrECSNotAvailable
 }
 
 // GetMetadata returns the metadata from the local ECS agent if available.
@@ -36,18 +53,58 @@ func GetMetadata() *agentpayload.ECSMetadataPayload {
 	if globalECSUtil != nil {
 		return globalECSUtil.getMetadata()
 	}
+
 	return nil
 }
 
-type ecsUtil struct{}
+type ecsUtil struct {
+	metadataSource string
+}
 
 func (e *ecsUtil) getMetadata() *agentpayload.ECSMetadataPayload {
-	payload, err := agentecs.GetPayload()
-	if err != nil && err.Error() != lastErr {
-		// Don't bubble up the error, just log it.
-		log.Errorf("error getting ECS metadata: %s", err)
-		lastErr = err.Error()
-		return nil
+	switch e.metadataSource {
+	case "agent":
+		payload, err := agentecs.GetPayload()
+		if err != nil && err.Error() != lastErr {
+			// Don't bubble up the error, just log it.
+			log.Errorf("error getting ECS metadata from agent: %s", err)
+			lastErr = err.Error()
+			return nil
+		}
+		return payload.(*agentpayload.ECSMetadataPayload)
+	case "api":
+		meta, err := ecs.GetTaskMetadata()
+		if err != nil && err.Error() != lastErr {
+			// Don't bubble up the error, just log it.
+			log.Errorf("error getting ECS metadata from API: %s", err)
+			lastErr = err.Error()
+			return nil
+		}
+		return parseTaskMetadata(meta)
 	}
-	return payload.(*agentpayload.ECSMetadataPayload)
+	return nil
+}
+
+func parseTaskMetadata(meta ecs.TaskMetadata) *agentpayload.ECSMetadataPayload {
+	containers := make([]*agentpayload.ECSMetadataPayload_Container, 0, len(meta.Containers))
+	for _, c := range meta.Containers {
+		containers = append(containers, &agentpayload.ECSMetadataPayload_Container{
+			DockerId:   c.DockerID,
+			DockerName: c.DockerName,
+			Name:       c.Name,
+		})
+	}
+
+	task := &agentpayload.ECSMetadataPayload_Task{
+		Arn:           meta.TaskARN,
+		DesiredStatus: meta.DesiredStatus,
+		KnownStatus:   meta.KnownStatus,
+		Family:        meta.Family,
+		Version:       meta.Version,
+		Containers:    containers,
+	}
+
+	return &agentpayload.ECSMetadataPayload{
+		Tasks: []*agentpayload.ECSMetadataPayload_Task{task},
+	}
 }

--- a/util/kubernetes/kubernetes.go
+++ b/util/kubernetes/kubernetes.go
@@ -275,9 +275,13 @@ func locateKubelet(cfg *Config) (string, error) {
 	var err error
 	hostname := cfg.KubeletHost
 	if cfg.KubeletHost == "" {
-		hostname, err = docker.GetHostname()
+		du, err := docker.GetDockerUtil()
 		if err != nil {
-			return "", fmt.Errorf("Unable to get hostname from docker: %s", err)
+			return "", fmt.Errorf("unable to get hostname from docker: %s", err)
+		}
+		hostname, err = du.GetHostname()
+		if err != nil {
+			return "", fmt.Errorf("unable to get hostname from docker: %s", err)
 		}
 	}
 


### PR DESCRIPTION
This change updates the process-agent to work in Fargate environments using the new local stats API.

In order for this to work we are depending on several changes in the upstream datadog-agent cookbook: https://github.com/DataDog/datadog-agent/pull/847 which is still not yet merged. Once this is merged we will re-pin our dependency. But in the meantime since the container API is changing, we will pin to this to unblock further changes in our Agent.
