### PR TITLE
Undeprecate top-level field Container.id

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -120,6 +120,7 @@ func fmtContainers(
 		}
 
 		chunk = append(chunk, &model.Container{
+			Id:          ctr.ID,
 			Type:        ctr.Type,
 			CpuLimit:    float32(ctr.CPULimit),
 			UserPct:     calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, lastRun),

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -166,7 +166,7 @@ enum ContainerHealth {
 
 message Container {
 	string type = 1;
-	string id = 2; // DEPRECATED - left in place to support previous versions
+	string id = 2;
 	string name = 3; // DEPRECATED - left in place to support previous versions
 	string image = 4; // DEPRECATED - left in place to support previous versions
 	float  cpuLimit = 5;


### PR DESCRIPTION
Small change: 

The container id is used in the backend resolver, so instead of searching all tags to find it, we can just leave it as a top-level field and omit it from the tags when processing in the backend.