### PR TITLE
Default listeners for docker + ecs

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -111,16 +111,22 @@ func main() {
 		log.Criticalf("Error reading dd-agent config: %s", err)
 		os.Exit(1)
 	}
+
 	yamlConf, err := config.NewYamlIfExists(opts.configPath)
 	if err != nil {
 		log.Criticalf("Error reading datadog.yaml: %s", err)
 		os.Exit(1)
 	}
 	if yamlConf != nil {
-		if err := config.SetupDDAgentConfig(opts.configPath); err == nil {
-			defer tagger.Stop()
-		}
+		config.SetupDDAgentConfig(opts.configPath)
 	}
+
+	if err := tagger.Init(); err == nil {
+		defer tagger.Stop()
+	} else {
+		log.Errorf("unable to initialize Datadog entity tagger: %s", err)
+	}
+
 	cfg, err := config.NewAgentConfig(agentConf, yamlConf)
 	if err != nil {
 		log.Criticalf("Error parsing config: %s", err)

--- a/config/config.go
+++ b/config/config.go
@@ -93,9 +93,13 @@ func NewDefaultAgentConfig() *AgentConfig {
 		// This is a hardcoded URL so parsing it should not fail
 		panic(err)
 	}
+
+	_, err = container.GetContainers()
+	canAccessContainers := err == nil
+
 	ac := &AgentConfig{
 		// We'll always run inside of a container.
-		Enabled:       container.IsAvailable(),
+		Enabled:       canAccessContainers,
 		APIEndpoint:   u,
 		LogFile:       defaultLogFilePath,
 		LogLevel:      "info",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,14 +116,12 @@ func TestDefaultConfig(t *testing.T) {
 	agentConfig := NewDefaultAgentConfig()
 
 	// assert that some sane defaults are set
-	assert.Equal(false, agentConfig.Enabled)
 	assert.Equal("info", agentConfig.LogLevel)
 	assert.Equal(true, agentConfig.AllowRealTime)
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 
 	os.Setenv("DOCKER_DD_AGENT", "yes")
 	agentConfig = NewDefaultAgentConfig()
-	assert.Equal(agentConfig.Enabled, false)
 	assert.Equal(os.Getenv("HOST_PROC"), "")
 	assert.Equal(os.Getenv("HOST_SYS"), "")
 	os.Setenv("DOCKER_DD_AGENT", "no")
@@ -149,7 +147,6 @@ func TestDDAgentConfigWithNewOpts(t *testing.T) {
 	assert.Equal("apikey_12", agentConfig.APIKey)
 	assert.Equal(5, agentConfig.QueueSize)
 	assert.Equal(false, agentConfig.AllowRealTime)
-	assert.Equal(false, agentConfig.Enabled)
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 }
 
@@ -182,7 +179,6 @@ func TestDDAgentConfigBothVersions(t *testing.T) {
 	assert.Equal("my-process-app.datadoghq.com", agentConfig.APIEndpoint.Hostname())
 	assert.Equal(10, agentConfig.QueueSize)
 	assert.Equal(false, agentConfig.AllowRealTime)
-	assert.Equal(false, agentConfig.Enabled)
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 }
 

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/cihub/seelog"
 	"gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-process-agent/util"
 )
 
@@ -151,9 +150,14 @@ func SetupDDAgentConfig(configPath string) error {
 	if err := ddconfig.Datadog.ReadInConfig(); err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}
-	if err := tagger.Init(); err != nil {
-		return fmt.Errorf("unable to initialize Datadog entity tagger: %s", err)
-	}
 
 	return nil
+}
+
+func init() {
+	defaultListeners := []ddconfig.Listeners{
+		{Name: "docker"},
+		{Name: "ecs"},
+	}
+	ddconfig.Datadog.SetDefault("listeners", defaultListeners)
 }


### PR DESCRIPTION
The latest ECS Fargate changes broke the default behavior for docker container collection, as a `listener` must be configured in order to find running docker containers.

Here, we're setting the yaml config `listener` defaults to docker + ecs so that we can try and find containers no matter what.

Also, I noticed that the tagger was not being initialized and stopped if there was no yaml config provided. This fixes that. 