### PR TITLE
Fix datadog.process.*.host_count metrics

### DIFF
--- a/checks/process.go
+++ b/checks/process.go
@@ -111,8 +111,8 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	p.lastCPUTime = cpuTimes[0]
 	p.lastRun = time.Now()
 
-	statsd.Client.Gauge("datadog.process.containers.host_count", totalProcs, []string{}, 1)
-	statsd.Client.Gauge("datadog.process.processes.host_count", totalContainers, []string{}, 1)
+	statsd.Client.Gauge("datadog.process.containers.host_count", totalContainers, []string{}, 1)
+	statsd.Client.Gauge("datadog.process.processes.host_count", totalProcs, []string{}, 1)
 	log.Debugf("collected processes in %s", time.Now().Sub(start))
 	return messages, nil
 }


### PR DESCRIPTION
The container and process metrics were swapped around, which I noticed today on a dashboard graph.