### PR TITLE
Send no hostname to backend on Fargate instances

### DIFF
--- a/checks/process.go
+++ b/checks/process.go
@@ -62,9 +62,11 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	if err != nil {
 		return nil, err
 	}
+
 	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
-		return nil, err
+		containers = []*docker.Container{}
+		log.Warn("Omitting container info for process check due to error: %s", err)
 	}
 
 	// End check early if this is our first run.

--- a/config/config.go
+++ b/config/config.go
@@ -274,6 +274,8 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig) (*AgentConfig, e
 		// Fargate tasks should have no concept of host names, so we're using the task ARN.
 		if taskMeta, err := ecsutil.GetTaskMetadata(); err == nil {
 			cfg.HostName = fmt.Sprintf("fargate_task:%s", taskMeta.TaskARN)
+		} else {
+			log.Errorf("Failed to retrieve Fargate task metadata: %s", err)
 		}
 	} else if hostname, err := getHostname(cfg.DDAgentPy, cfg.DDAgentBin, cfg.DDAgentPyEnv); err == nil {
 		cfg.HostName = hostname

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
-	"github.com/DataDog/datadog-agent/pkg/util/ecs"
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/DataDog/datadog-process-agent/util"
+
 	log "github.com/cihub/seelog"
 	"github.com/go-ini/ini"
 )
@@ -268,12 +269,14 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig) (*AgentConfig, e
 		return nil, err
 	}
 
-	if ecs.IsFargateInstance() { // Fargate tasks should have no concept of host names.
-		cfg.HostName = ""
+	cfg.HostName = ""
+	if ecsutil.IsFargateInstance() {
+		// Fargate tasks should have no concept of host names, so we're using the task ARN.
+		if taskMeta, err := ecsutil.GetTaskMetadata(); err == nil {
+			cfg.HostName = fmt.Sprintf("fargate_task:%s", taskMeta.TaskARN)
+		}
 	} else if hostname, err := getHostname(cfg.DDAgentPy, cfg.DDAgentBin, cfg.DDAgentPyEnv); err == nil {
 		cfg.HostName = hostname
-	} else {
-		cfg.HostName = ""
 	}
 
 	return cfg, nil


### PR DESCRIPTION
Starting by simply detecting whether we're in a fargate instance, and overwriting the hostname (even if it's set via the `DD_HOSTNAME` env variable) to be an empty string.

We may need to send something unique here for the backend key but I'll look into alternatives on the backend first.