### PR TITLE
Reducing logging noise and add better error handling

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -7,11 +7,11 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
 	"github.com/DataDog/datadog-process-agent/statsd"
+	"github.com/DataDog/datadog-process-agent/util/container"
 	"github.com/DataDog/datadog-process-agent/util/kubernetes"
 )
 

--- a/checks/container.go
+++ b/checks/container.go
@@ -1,6 +1,7 @@
 package checks
 
 import (
+	"errors"
 	"runtime"
 	"time"
 
@@ -43,9 +44,9 @@ func (c *ContainerCheck) RealTime() bool { return false }
 // stats for each container.
 func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	start := time.Now()
-	containers, err := container.GetContainers()
-	if err != nil && err != docker.ErrDockerNotAvailable {
-		return nil, err
+	containers, errs := container.GetContainers()
+	if len(errs) != 0 {
+		return nil, errors.New("failed to retrieve list of containers")
 	}
 
 	// End check early if this is our first run.

--- a/checks/container.go
+++ b/checks/container.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"errors"
 	"runtime"
 	"time"
 
@@ -44,9 +43,9 @@ func (c *ContainerCheck) RealTime() bool { return false }
 // stats for each container.
 func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	start := time.Now()
-	containers, errs := container.GetContainers()
-	if len(errs) != 0 {
-		return nil, errors.New("failed to retrieve list of containers")
+	containers, err := container.GetContainers()
+	if err != nil {
+		return nil, err
 	}
 
 	// End check early if this is our first run.

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -4,10 +4,10 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
+	"github.com/DataDog/datadog-process-agent/util/container"
 )
 
 // RTContainer is a singleton RTContainerCheck.

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -1,6 +1,7 @@
 package checks
 
 import (
+	"errors"
 	"runtime"
 	"time"
 
@@ -36,9 +37,9 @@ func (r *RTContainerCheck) RealTime() bool { return true }
 
 // Run runs the real-time container check getting container-level stats from the Cgroups and Docker APIs.
 func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
-	containers, err := container.GetContainers()
-	if err != nil && err != docker.ErrDockerNotAvailable {
-		return nil, err
+	containers, errs := container.GetContainers()
+	if len(errs) != 0 {
+		return nil, errors.New("failed to retrieve list of containers")
 	}
 
 	// End check early if this is our first run.

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"errors"
 	"runtime"
 	"time"
 
@@ -37,9 +36,9 @@ func (r *RTContainerCheck) RealTime() bool { return true }
 
 // Run runs the real-time container check getting container-level stats from the Cgroups and Docker APIs.
 func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
-	containers, errs := container.GetContainers()
-	if len(errs) != 0 {
-		return nil, errors.New("failed to retrieve list of containers")
+	containers, err := container.GetContainers()
+	if err != nil {
+		return nil, err
 	}
 
 	// End check early if this is our first run.

--- a/checks/process.go
+++ b/checks/process.go
@@ -62,12 +62,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	if err != nil {
 		return nil, err
 	}
-
-	containers, errs := container.GetContainers()
-	if len(errs) != 0 {
-		containers = []*docker.Container{}
-		log.Warn("omitting container info for process check due to retrieval errors")
-	}
+	containers, _ := container.GetContainers()
 
 	// End check early if this is our first run.
 	if p.lastProcs == nil {

--- a/checks/process.go
+++ b/checks/process.go
@@ -63,10 +63,10 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 		return nil, err
 	}
 
-	containers, err := container.GetContainers()
-	if err != nil && err != docker.ErrDockerNotAvailable {
+	containers, errs := container.GetContainers()
+	if len(errs) != 0 {
 		containers = []*docker.Container{}
-		log.Warn("Omitting container info for process check due to error: %s", err)
+		log.Warn("omitting container info for process check due to retrieval errors")
 	}
 
 	// End check early if this is our first run.

--- a/checks/process.go
+++ b/checks/process.go
@@ -10,11 +10,11 @@ import (
 	"github.com/DataDog/gopsutil/process"
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
 	"github.com/DataDog/datadog-process-agent/statsd"
+	"github.com/DataDog/datadog-process-agent/util/container"
 )
 
 // Process is a singleton ProcessCheck.

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
-	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
@@ -55,11 +54,7 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if err != nil {
 		return nil, err
 	}
-	containers, errs := container.GetContainers()
-	if len(errs) != 0 {
-		containers = []*docker.Container{}
-		log.Warn("omitting container info for process check due to retrieval errors")
-	}
+	containers, _ := container.GetContainers()
 
 	// End check early if this is our first run.
 	if r.lastProcs == nil {

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
+	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
+	"github.com/DataDog/datadog-process-agent/util/container"
 )
 
 // RTProcess is a singleton RTProcessCheck.
@@ -56,7 +57,8 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	}
 	containers, err := container.GetContainers()
 	if err != nil && err != docker.ErrDockerNotAvailable {
-		return nil, err
+		containers = []*docker.Container{}
+		log.Warn("Omitting container info for process check due to error: %s", err)
 	}
 
 	// End check early if this is our first run.

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -55,10 +55,10 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if err != nil {
 		return nil, err
 	}
-	containers, err := container.GetContainers()
-	if err != nil && err != docker.ErrDockerNotAvailable {
+	containers, errs := container.GetContainers()
+	if len(errs) != 0 {
 		containers = []*docker.Container{}
-		log.Warn("Omitting container info for process check due to error: %s", err)
+		log.Warn("omitting container info for process check due to retrieval errors")
 	}
 
 	// End check early if this is our first run.

--- a/config/config.go
+++ b/config/config.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/container"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/DataDog/datadog-process-agent/util"
+	"github.com/DataDog/datadog-process-agent/util/container"
 
 	log "github.com/cihub/seelog"
 	"github.com/go-ini/ini"

--- a/config/config.go
+++ b/config/config.go
@@ -96,8 +96,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 		panic(err)
 	}
 
-	_, errs := container.GetContainers()
-	canAccessContainers := len(errs) == 0
+	_, err = container.GetContainers()
+	canAccessContainers := err == nil
 
 	ac := &AgentConfig{
 		// We'll always run inside of a container.

--- a/config/config.go
+++ b/config/config.go
@@ -96,8 +96,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 		panic(err)
 	}
 
-	_, err = container.GetContainers()
-	canAccessContainers := err == nil
+	_, errs := container.GetContainers()
+	canAccessContainers := len(errs) == 0
 
 	ac := &AgentConfig{
 		// We'll always run inside of a container.

--- a/util/container/container.go
+++ b/util/container/container.go
@@ -3,6 +3,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 
 	log "github.com/cihub/seelog"
@@ -31,7 +32,7 @@ func initContainerListeners() {
 // GetContainers is the unique method that returns all containers on the host (or in the task)
 // and that other agents can consume so that we don't have to convert all containers to the format.
 // NOTE: This is a modified copy of datadog-agent/pkg/util/container to prevent noisy logging
-func GetContainers() ([]*docker.Container, []error) {
+func GetContainers() ([]*docker.Container, error) {
 	if listeners == nil {
 		initContainerListeners()
 	}
@@ -68,12 +69,12 @@ func GetContainers() ([]*docker.Container, []error) {
 	}
 
 	if succeeded { // Some container access method succeeded so drop errors from other access methods
-		errs = []error{}
+		return containers, nil
 	}
 
 	for _, e := range errs {
 		log.Error(e)
 	}
 
-	return containers, errs
+	return containers, errors.New("failed to get containers from any source")
 }

--- a/util/container/container.go
+++ b/util/container/container.go
@@ -66,11 +66,12 @@ func GetContainers() ([]*docker.Container, []error) {
 	}
 
 	if succeeded { // Some container access method succeeded so drop errors from other access methods
-		return containers, []error{}
-	} else {
-		for _, e := range errs {
-			log.Error(e)
-		}
-		return containers, errs
+		errs = []error{}
 	}
+
+	for _, e := range errs {
+		log.Error(e)
+	}
+
+	return containers, errs
 }

--- a/util/container/container.go
+++ b/util/container/container.go
@@ -1,0 +1,61 @@
+package container
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs"
+)
+
+var (
+	listeners []config.Listeners
+)
+
+// Unmarshal the listeners once and store the result
+func initContainerListeners() {
+	if err := config.Datadog.UnmarshalKey("listeners", &listeners); err != nil {
+		log.Errorf("unable to parse listeners from the datadog config - %s", err)
+		listeners = []config.Listeners{}
+	}
+}
+
+// GetContainers is the unique method that returns all containers on the host (or in the task)
+// and that other agents can consume so that we don't have to convert all containers to the format.
+func GetContainers() ([]*docker.Container, error) {
+	if listeners == nil {
+		initContainerListeners()
+	}
+
+	var err error
+	containers := make([]*docker.Container, 0)
+	ctrListConfig := docker.ContainerListConfig{
+		IncludeExited: false,
+		FlagExcluded:  false,
+	}
+
+	for _, l := range listeners {
+		switch l.Name {
+		case "docker":
+			du, err := docker.GetDockerUtil()
+			if err != nil {
+				log.Errorf("unable to connect to docker, passing this provider - %s", err)
+				continue
+			}
+			ctrs, err := du.Containers(&ctrListConfig)
+			if err != nil {
+				log.Errorf("failed to get container list from docker - %s", err)
+			}
+			containers = append(containers, ctrs...)
+		case "ecs":
+			ctrs, err := ecs.GetContainers()
+			if err != nil {
+				log.Errorf("failed to get container list from ecs - %s", err)
+			}
+			containers = append(containers, ctrs...)
+		default:
+			log.Warnf("listener %s is not a known container provider, skipping it", l.Name)
+		}
+	}
+	return containers, err
+}

--- a/util/container/container.go
+++ b/util/container/container.go
@@ -1,3 +1,5 @@
+// +build docker
+
 package container
 
 import (

--- a/util/container/container.go
+++ b/util/container/container.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"fmt"
+
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -16,46 +18,59 @@ var (
 func initContainerListeners() {
 	if err := config.Datadog.UnmarshalKey("listeners", &listeners); err != nil {
 		log.Errorf("unable to parse listeners from the datadog config - %s", err)
-		listeners = []config.Listeners{}
+		// Default to all known listeners on parse failure
+		listeners = []config.Listeners{
+			{Name: "ecs"},
+			{Name: "docker"},
+		}
 	}
 }
 
 // GetContainers is the unique method that returns all containers on the host (or in the task)
 // and that other agents can consume so that we don't have to convert all containers to the format.
-func GetContainers() ([]*docker.Container, error) {
+// NOTE: This is a modified copy of datadog-agent/pkg/util/container to prevent noisy logging
+func GetContainers() ([]*docker.Container, []error) {
 	if listeners == nil {
 		initContainerListeners()
 	}
 
-	var err error
 	containers := make([]*docker.Container, 0)
+	errs := make([]error, 0)
 	ctrListConfig := docker.ContainerListConfig{
 		IncludeExited: false,
 		FlagExcluded:  false,
 	}
+	succeeded := false
 
 	for _, l := range listeners {
 		switch l.Name {
 		case "docker":
-			du, err := docker.GetDockerUtil()
-			if err != nil {
-				log.Errorf("unable to connect to docker, passing this provider - %s", err)
-				continue
+			if du, err := docker.GetDockerUtil(); err == nil {
+				if ctrs, err := du.Containers(&ctrListConfig); err == nil {
+					succeeded = true
+					containers = append(containers, ctrs...)
+					continue
+				}
+				errs = append(errs, fmt.Errorf("failed to get container list from docker - %s", err))
+			} else {
+				errs = append(errs, fmt.Errorf("unable to connect to docker - %s", err))
 			}
-			ctrs, err := du.Containers(&ctrListConfig)
-			if err != nil {
-				log.Errorf("failed to get container list from docker - %s", err)
-			}
-			containers = append(containers, ctrs...)
 		case "ecs":
-			ctrs, err := ecs.GetContainers()
-			if err != nil {
-				log.Errorf("failed to get container list from ecs - %s", err)
+			if ctrs, err := ecs.GetContainers(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to get container list from ecs - %s", err))
+			} else {
+				succeeded = true
+				containers = append(containers, ctrs...)
 			}
-			containers = append(containers, ctrs...)
-		default:
-			log.Warnf("listener %s is not a known container provider, skipping it", l.Name)
 		}
 	}
-	return containers, err
+
+	if succeeded { // Some container access method succeeded so drop errors from other access methods
+		return containers, []error{}
+	} else {
+		for _, e := range errs {
+			log.Error(e)
+		}
+		return containers, errs
+	}
 }

--- a/util/container/containers_nodocker.go
+++ b/util/container/containers_nodocker.go
@@ -6,6 +6,6 @@ import "github.com/DataDog/datadog-agent/pkg/util/docker"
 
 // GetContainers is the unique method that returns all containers on the host (or in the task)
 // and that other agents can consume so that we don't have to convert all containers to the format.
-func GetContainers() ([]*docker.Container, []error) {
-	return *docker.Container{}, []error{}
+func GetContainers() ([]*docker.Container, error) {
+	return *docker.Container{}, nil
 }

--- a/util/container/containers_nodocker.go
+++ b/util/container/containers_nodocker.go
@@ -1,0 +1,11 @@
+// +build !docker
+
+package container
+
+import "github.com/DataDog/datadog-agent/pkg/util/docker"
+
+// GetContainers is the unique method that returns all containers on the host (or in the task)
+// and that other agents can consume so that we don't have to convert all containers to the format.
+func GetContainers() ([]*docker.Container, []error) {
+	return *docker.Container{}, []error{}
+}


### PR DESCRIPTION
- Cleaning up a lot of logging noise by copying and modifying `datadog-agent/pkg/util/container`. 
- We're also now better handling errors returned by `GetContainers()`.

Whats left:
- Still a bit of noise when getting container lists from ecs (`datadog-agent/pkg/util/ecs/common.go`) (see below logs)

```
2018-01-10 17:50:16 ERROR (common.go:65) - unable to get the container list from ecs
2018-01-10 17:50:18 ERROR (common.go:50) - unable to retrieve task metadata
2018-01-10 17:50:18 ERROR (common.go:65) - unable to get the container list from ecs
2018-01-10 17:50:20 ERROR (common.go:50) - unable to retrieve task metadata
2018-01-10 17:50:20 ERROR (common.go:65) - unable to get the container list from ecs
2018-01-10 17:50:22 ERROR (common.go:50) - unable to retrieve task metadata
2018-01-10 17:50:22 ERROR (common.go:65) - unable to get the container list from ecs
2018-01-10 17:50:24 ERROR (common.go:50) - unable to retrieve task metadata
2018-01-10 17:50:24 ERROR (common.go:65) - unable to get the container list from ecs
2018-01-10 17:50:24 ERROR (common.go:50) - unable to retrieve task metadata
2018-01-10 17:50:24 ERROR (common.go:65) - unable to get the container list from ecs
2018-01-10 17:50:24 INFO (collector.go:112) - Finish check #160 in 35.528599ms
```

I'll see if I can get the above logging statements removed upstream. It does seem like it'd be better to have them logged by the caller regardless.