### PR TITLE
Process agent logging reduction on container retrieval failures

### DIFF
--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -156,7 +156,6 @@ func SetupDDAgentConfig(configPath string) error {
 func init() {
 	defaultListeners := []ddconfig.Listeners{
 		{Name: "docker"},
-		{Name: "ecs"},
 	}
 	ddconfig.Datadog.SetDefault("listeners", defaultListeners)
 }

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-process-agent/util"
+	"github.com/DataDog/datadog-process-agent/util/container"
 )
 
 // YamlAgentConfig is a sturcutre used for marshaling the datadog.yaml configuratio
@@ -154,8 +155,5 @@ func SetupDDAgentConfig(configPath string) error {
 }
 
 func init() {
-	defaultListeners := []ddconfig.Listeners{
-		{Name: "docker"},
-	}
-	ddconfig.Datadog.SetDefault("listeners", defaultListeners)
+	ddconfig.Datadog.SetDefault("listeners", container.GetDefaultListeners())
 }

--- a/util/container/container.go
+++ b/util/container/container.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	listeners []config.Listeners
-	// hasFatalError stores whether a listener has fatally error'd or not
+	// hasFatalError stores whether a listener has fatally error'd, to see if we should keep accessing its containers
 	hasFatalError map[string]bool
 )
 

--- a/util/container/containers_nodocker.go
+++ b/util/container/containers_nodocker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
+// GetDefaultListeners returns the default auto-discovery listeners, for use in container retrieval
 func GetDefaultListeners() []config.Listeners {
 	return nil
 }

--- a/util/container/containers_nodocker.go
+++ b/util/container/containers_nodocker.go
@@ -2,7 +2,14 @@
 
 package container
 
-import "github.com/DataDog/datadog-agent/pkg/util/docker"
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+func GetDefaultListeners() []config.Listeners {
+	return nil
+}
 
 // GetContainers is the unique method that returns all containers on the host (or in the task)
 // and that other agents can consume so that we don't have to convert all containers to the format.


### PR DESCRIPTION
- Removes `ecs` as a default listener
- If docker permanently fails to connect, we should not keep attempting to connect (or logging it)

Still testing to make sure this works as expected locally