### PR TITLE
Make sure we respect the configuration logging preferences

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,6 @@ def os
     end
   end
   
-  
 desc "Setup dependencies"
 task :deps do
   system("go get github.com/Masterminds/glide")

--- a/agent/main.go
+++ b/agent/main.go
@@ -4,8 +4,9 @@ package main
 
 import (
 	"flag"
-	"github.com/DataDog/datadog-process-agent/config"
 	_ "net/http/pprof"
+
+	"github.com/DataDog/datadog-process-agent/config"
 )
 
 func main() {
@@ -27,5 +28,4 @@ func main() {
 
 	// Invoke the Agent
 	runAgent(exit)
-
 }

--- a/agent/main_common.go
+++ b/agent/main_common.go
@@ -68,7 +68,6 @@ to your datadog.conf file.
 Exiting.`
 
 func runAgent(exit chan bool) {
-
 	if opts.version {
 		fmt.Println(versionString())
 		os.Exit(0)

--- a/agent/main_nodocker.go
+++ b/agent/main_nodocker.go
@@ -3,13 +3,15 @@
 package main
 
 import (
-	log "github.com/cihub/seelog"
 	"os"
 	"os/signal"
 	"syscall"
+
+	log "github.com/cihub/seelog"
 )
 
 func initMetadataProviders() {
+	// No-op
 }
 
 // Handles signals - tells us whether we should exit.

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -5,7 +5,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	//	"log"
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"
@@ -36,7 +35,6 @@ var winopts struct {
 
 func init() {
 	fmt.Printf("main_windows.init()")
-
 }
 
 type myservice struct{}
@@ -102,6 +100,7 @@ func runService(isDebug bool) {
 	}
 	elog.Info(0x40000004, ServiceName)
 }
+
 func EnableLoggingToFile() {
 	seeConfig := `
 	<seelog minlevel="debug">
@@ -185,13 +184,10 @@ func main() {
 
 	}
 
-	// if we are an interactive session, then just invoke the agent on the command line.
-
 	exit := make(chan bool)
 
 	// Invoke the Agent
 	runAgent(exit)
-
 }
 
 func startService() error {

--- a/checks/process.go
+++ b/checks/process.go
@@ -262,3 +262,23 @@ func chunkProcesses(msgs []*model.Process, chunks int) [][]*model.Process {
 	}
 	return chunked
 }
+
+func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
+	if deltaTime == 0 {
+		return 0
+	}
+
+	// Calculates utilization split across all CPUs. A busy-loop process
+	// on a 2-CPU-core system would be reported as 50% instead of 100%.
+	overalPct := (deltaProc / deltaTime) * 100
+
+	// Sometimes we get values that don't make sense, so we clamp to 100%
+	if overalPct > 100 {
+		overalPct = 100
+	}
+
+	// In order to emulate task mgr, we divide by number of CPUs.
+	// Task mgr displays percentage of available CPU (so a busy loop process
+	// on a 2 core CPU is 50%)
+	return float32(overalPct / numCPU)
+}

--- a/checks/process_nix.go
+++ b/checks/process_nix.go
@@ -49,21 +49,3 @@ func formatCPU(fp *process.FilledProcess, t2, t1, syst2, syst1 cpu.TimesStat) *m
 		SystemTime: int64(t2.System),
 	}
 }
-
-func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
-	if deltaTime == 0 {
-		return 0
-	}
-
-	// Calculates utilization split across all CPUs. A busy-loop process
-	// on a 2-CPU-core system would be reported as 50% instead of 100%.
-	overalPct := (deltaProc / deltaTime) * 100
-
-	// Sometimes we get values that don't make sense, so we clamp to 100%
-	if overalPct > 100 {
-		overalPct = 100
-	}
-
-	// In order to emulate top we multiply utilization by # of CPUs so a busy loop would be 100%.
-	return float32(overalPct * numCPU)
-}

--- a/checks/process_windows.go
+++ b/checks/process_windows.go
@@ -11,7 +11,6 @@ import (
 )
 
 func formatUser(fp *process.FilledProcess) *model.ProcessUser {
-
 	return &model.ProcessUser{
 		Name: fp.Username,
 	}
@@ -33,23 +32,4 @@ func formatCPU(fp *process.FilledProcess, t2, t1, syst2, syst1 cpu.TimesStat) *m
 		UserTime:   int64(t2.User),
 		SystemTime: int64(t2.System),
 	}
-}
-func calculatePct(deltaProc, deltaTime, numCPU float64) float32 {
-	if deltaTime == 0 {
-		return 0
-	}
-
-	// Calculates utilization split across all CPUs. A busy-loop process
-	// on a 2-CPU-core system would be reported as 50% instead of 100%.
-	overalPct := (deltaProc / deltaTime) * 100
-
-	// Sometimes we get values that don't make sense, so we clamp to 100%
-	if overalPct > 100 {
-		overalPct = 100
-	}
-
-	// In order to emulate task mgr, we divide by number of CPUs.
-	// Task mgr displays percentage of available CPU (so a busy loop process
-	// on a 2 core CPU is 50%)
-	return float32(overalPct / numCPU)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -266,9 +266,9 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig) (*AgentConfig, e
 	}
 
 	// (Re)configure the logging from our configuration
-	//if err := NewLoggerLevel(cfg.LogLevel, cfg.LogFile); err != nil {
-	//		return nil, err
-	//	}
+	if err := NewLoggerLevel(cfg.LogLevel, cfg.LogFile); err != nil {
+		return nil, err
+	}
 
 	cfg.HostName = ""
 	if ecsutil.IsFargateInstance() {


### PR DESCRIPTION
Testing the latest master for regressions on linux at the moment and noticed that we're not logging anything. 

This will fix that by respecting the configuration settings.

Also did a little `gofmt` cleanup + some of the quicker things mentioned in the last PR