### PR TITLE
[config] Read additional config items from the parsed datadog.yaml

### DIFF
--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -134,6 +134,11 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 	if yc.Process.DDAgentBin != "" {
 		agentConf.DDAgentBin = yc.Process.DDAgentBin
 	}
+
+	// Pull additional parameters from the global config file.
+	agentConf.LogLevel = ddconfig.Datadog.GetString("log_level")
+	agentConf.StatsdPort = ddconfig.Datadog.GetInt("dogstatsd_port")
+
 	return agentConf, nil
 }
 


### PR DESCRIPTION
We want to stop passing env variables to the Agent (https://github.com/DataDog/datadog-agent/blob/6.0.0-beta.8/pkg/collector/corechecks/embed/process_agent.go#L79-L85) so these are the last two bits we weren't reading in our Agent.