### PR TITLE
 Windows build should allow overridden hostnames

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -414,10 +414,10 @@ func getHostname(ddAgentPy, ddAgentBin string, ddAgentEnv []string) (string, err
 		cmd = exec.Command(ddAgentPy, "-c", getHostnameCmd)
 	}
 
+	// Copying all environment variables to child process
 	// Windows: Required, so the child process can load DLLs, etc.
 	// Linux:   Optional, but will make use of DD_HOSTNAME and DOCKER_DD_AGENT if they exist
 	osEnv := os.Environ()
-
 	cmd.Env = append(ddAgentEnv, osEnv...)
 
 	var stdout, stderr bytes.Buffer

--- a/config/config_nix.go
+++ b/config/config_nix.go
@@ -4,4 +4,11 @@ package config
 
 const (
 	defaultLogFilePath = "/var/log/datadog/process-agent.log"
+
+	// Agent 5
+	defaultDDAgentPy    = "/opt/datadog-agent/embedded/bin/python"
+	defaultDDAgentPyEnv = "PYTHONPATH=/opt/datadog-agent/agent"
+
+	// Agent 6
+	defaultDDAgentBin = "/opt/datadog-agent/bin/agent/agent"
 )

--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -4,4 +4,11 @@ package config
 
 const (
 	defaultLogFilePath = "c:\\programdata\\datadog\\logs\\process-agent.log"
+
+	// Agent 5
+	defaultDDAgentPy    = "c:\\Program Files\\Datadog\\Datadog Agent\\embedded\\python.exe"
+	defaultDDAgentPyEnv = "PYTHONPATH=c:\\Program Files\\Datadog\\Datadog Agent\\agent"
+
+	// Agent 6
+	defaultDDAgentBin = "c:\\Program Files\\Datadog\\Datadog Agent\\embedded\\agent.exe"
 )

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -130,7 +130,7 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 			log.Warn("Overriding the configured process limit because it exceeds maximum")
 		}
 	}
-	agentConf.DDAgentBin = "/opt/datadog-agent/bin/agent/agent"
+	agentConf.DDAgentBin = defaultDDAgentBin
 	if yc.Process.DDAgentBin != "" {
 		agentConf.DDAgentBin = yc.Process.DDAgentBin
 	}


### PR DESCRIPTION
Right now the Windows build does not respect overridden hostnames, this should fix that.
