### PR TITLE
Fix processing of process_agent_enabled flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -186,7 +186,7 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig) (*AgentConfig, e
 		if enabled, err := isAffirmative(v); enabled {
 			cfg.Enabled = true
 			cfg.EnabledChecks = processChecks
-		} else if !enabled && err == nil {
+		} else if !enabled || err != nil {
 			cfg.Enabled = false
 		}
 


### PR DESCRIPTION
By default, there's no `process_agent_enabled` flag in the config at all (in a clean install).  `isAffirmative ()` returns an error in that case https://github.com/DataDog/datadog-process-agent/blob/master/config/config.go#L399 which was causing us to skip the else clause.