### PR TITLE
Correctly disable process-agent on windows

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -186,7 +186,7 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig) (*AgentConfig, e
 		if enabled, err := isAffirmative(v); enabled {
 			cfg.Enabled = true
 			cfg.EnabledChecks = processChecks
-		} else if !enabled || err != nil {
+		} else if !enabled && err == nil { // Only want to disable the process agent if it's explicitly disabled
 			cfg.Enabled = false
 		}
 

--- a/util/container/containers_nodocker.go
+++ b/util/container/containers_nodocker.go
@@ -15,5 +15,5 @@ func GetDefaultListeners() []config.Listeners {
 // GetContainers is the unique method that returns all containers on the host (or in the task)
 // and that other agents can consume so that we don't have to convert all containers to the format.
 func GetContainers() ([]*docker.Container, error) {
-	return make([]*docker.Container, 0), nil
+	return make([]*docker.Container, 0), docker.ErrNotImplemented
 }


### PR DESCRIPTION
While #105 fixes default agent behavior on Windows, it looks like it might be introducing a bug on linux. 

In this case, container checks will not automatically be enabled since it defaults to `cfg.Enabled = false` when `process_agent_enabled` is not in the config.

Since the original should-enable logic is sourced by:

```
_, err = container.GetContainers()
canAccessContainers := err == nil

ac := &AgentConfig{
  ...
  Enabled:       canAccessContainers,
  ...
}
```

It makes more sense for `GetContainers()` to return an error on windows.