### PR TITLE
Move to go 1.9.4 for circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    GODIST: "go1.8.3.linux-amd64.tar.gz"
+    GODIST: "go1.9.4.linux-amd64.tar.gz"
     GOPATH: /home/ubuntu/.go_workspace
     IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
     GLIDE_PATH: "$GOPATH/src/github.com/Masterminds/glide"


### PR DESCRIPTION
Per https://github.com/DataDog/dd-go/issues/5252

https://circleci.com/gh/DataDog/datadog-process-agent/355#config/containers/0

^ shows that the config was picked up and ran tests successfully.