### PR TITLE
Always set default listener to docker and optionally ecs if it exists

### DIFF
--- a/util/container/container.go
+++ b/util/container/container.go
@@ -22,10 +22,7 @@ var (
 
 // Unmarshal the listeners once and store the result
 func initContainerListeners() {
-	if err := config.Datadog.UnmarshalKey("listeners", &listeners); err != nil {
-		log.Errorf("unable to parse listeners from the datadog config, using default listeners - %s", err)
-		listeners = GetDefaultListeners()
-	}
+	listeners = GetDefaultListeners()
 	hasFatalError = make(map[string]bool)
 }
 


### PR DESCRIPTION
Testing the latest agent 6 RC on kubernetes and found this bug.

We might start the process-agent with a autodiscovery listener of `kubelet` due to: 

https://github.com/DataDog/datadog-agent/blob/3f9f7277c9c48550dffbf108ca4d9215f0232262/Dockerfiles/agent/entrypoint.sh#L38

which sets the config as: 

https://github.com/DataDog/datadog-agent/blob/3f9f7277c9c48550dffbf108ca4d9215f0232262/Dockerfiles/agent/datadog-kubernetes.yaml

This means we will not be able to gather docker container data since it requires the `docker` listener to be present.

**I propose that on the process-agent, we ignore the `listener` configuration value of the main agent and always try `docker`, and `ecs` (when detected).**