### PR TITLE
Remove kubelet build tag for windows

### DIFF
--- a/gorake.rb
+++ b/gorake.rb
@@ -38,8 +38,6 @@ def go_build(program, opts={})
   cmd += ' -race' if opts[:race]
   if os != "windows"
     cmd += ' -tags \'docker kubelet kubeapiserver\''
-  else
-    cmd += ' -tags \'kubelet\''
   end
   print "cmd"
 


### PR DESCRIPTION
We don't support containers on windows so there's really no point in starting the kubelet tagger (via the `kubelet` build tag)

This cleans up some extra logging that I found in `process.log` (instead of `process-agent.log`)