### PR TITLE
[config] Support proxy config for Agent 6

### DIFF
--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	ddutil "github.com/DataDog/datadog-agent/pkg/util"
 	log "github.com/cihub/seelog"
 	"gopkg.in/yaml.v2"
 
@@ -139,6 +140,7 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 	// Pull additional parameters from the global config file.
 	agentConf.LogLevel = ddconfig.Datadog.GetString("log_level")
 	agentConf.StatsdPort = ddconfig.Datadog.GetInt("dogstatsd_port")
+	agentConf.Transport = ddutil.CreateHTTPTransport()
 
 	return agentConf, nil
 }


### PR DESCRIPTION
Pushes the configuration of transport to the config package so we can share the transport creator in Agent 6 with full support proxy configuration built in. See [util/common.go](https://github.com/DataDog/datadog-agent/blob/bc1f3ca4afde0a553098efa5c11a0f309b6b4156/pkg/util/common.go#L186) for the full function.

The potential breaking change here is changing the timeouts for Agent 6. We could override these outside of getting the transport but I'm not sure it's worth it. I assume if the transport works for core Agent 6 then it should be good for us. Thoughts?