### PR TITLE
Only use ecs.GetContainers() for Fargate

### DIFF
--- a/util/container/container.go
+++ b/util/container/container.go
@@ -29,8 +29,8 @@ func initContainerListeners() {
 // GetDefaultListeners returns the default auto-discovery listeners, for use in container retrieval
 func GetDefaultListeners() []config.Listeners {
 	l := []config.Listeners{{Name: "docker"}}
-	// If we can detect that this is an ecs or fargate instance, lets add it as well
-	if ecs.IsInstance() || ecs.IsFargateInstance() {
+	// If we can detect that this is a fargate instance, lets add it as well
+	if ecs.IsFargateInstance() {
 		l = append(l, config.Listeners{Name: "ecs"})
 	}
 	return l
@@ -73,9 +73,9 @@ func GetContainers() ([]*docker.Container, error) {
 				}
 				errs = append(errs, fmt.Errorf("unable to connect to docker - %s", err))
 			}
-		case "ecs":
+		case "ecs": // Fargate containers
 			if ctrs, err := ecs.GetContainers(); err != nil {
-				errs = append(errs, fmt.Errorf("failed to get container list from ecs - %s", err))
+				errs = append(errs, fmt.Errorf("failed to get container list from fargate - %s", err))
 			} else {
 				succeeded = true
 				containers = append(containers, ctrs...)


### PR DESCRIPTION
ECS docker containers are retrieved via `docker.GetDockerUtil()`, so on ECS instances we were erroneously trying to fetch Fargate containers which spew false negatives in the logs, even though things were running fine:

```
2018-03-26 16:04:10 ERROR (common.go:64) - unable to get the container list from ecs
2018-03-26 16:04:12 ERROR (common.go:50) - unable to retrieve task metadata
2018-03-26 16:04:12 ERROR (common.go:64) - unable to get the container list from ecs
2018-03-26 16:04:14 ERROR (common.go:50) - unable to retrieve task metadata
2018-03-26 16:04:14 ERROR (common.go:64) - unable to get the container list from ecs
2018-03-26 16:04:15 ERROR (common.go:50) - unable to retrieve task metadata
```