### PR TITLE
Fix error message for process-agent not enabled in v6

### DIFF
--- a/agent/main_common.go
+++ b/agent/main_common.go
@@ -61,11 +61,20 @@ func versionString() string {
 	return buf.String()
 }
 
-const agentDisabledMessage = `process-agent not enabled.
+const (
+	agent5DisabledMessage = `process-agent not enabled.
 Set env var DD_PROCESS_AGENT_ENABLED=true or add
 process_agent_enabled: true
 to your datadog.conf file.
 Exiting.`
+
+	agent6DisabledMessage = `process-agent not enabled.
+Set env var DD_PROCESS_AGENT_ENABLED=true or add
+process_config:
+  enabled: "true"
+to your datadog.yaml file.
+Exiting.`
+)
 
 func runAgent(exit chan bool) {
 	if opts.version {
@@ -125,7 +134,11 @@ func runAgent(exit chan bool) {
 
 	// Exit if agent is not enabled and we're not debugging a check.
 	if !cfg.Enabled && opts.check == "" {
-		log.Info(agentDisabledMessage)
+		if yamlConf != nil {
+			log.Infof(agent6DisabledMessage)
+		} else {
+			log.Info(agent5DisabledMessage)
+		}
 
 		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
 		// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit


### PR DESCRIPTION
```
$ DD_LOGS_STDOUT=yes process-agent
...
2018-03-26 23:14:06 INFO (main_common.go:137) - process-agent not enabled.
Set env var DD_PROCESS_AGENT_ENABLED=true or add
process_config:
  enabled: "true"
to your datadog.yaml file.
Exiting.
```

For: https://trello.com/c/vPqGyVKK/878-version-specific-log-instructions