### PR TITLE
Eliminate proxy expvar from info page.

### DIFF
--- a/agent/info.go
+++ b/agent/info.go
@@ -235,16 +235,6 @@ func initInfo(conf *config.AgentConfig) error {
 		expvar.Publish("container_count", expvar.Func(publishContainerCount))
 		expvar.Publish("queue_size", expvar.Func(publishQueueSize))
 		expvar.Publish("container_id", expvar.Func(publishContainerID))
-
-		var proxyURL string
-		if conf != nil && conf.Transport.Proxy != nil {
-			u, err := conf.Transport.Proxy(&http.Request{})
-			if err == nil {
-				proxyURL = u.String()
-			}
-		}
-		expvar.NewString("proxy_url").Set(proxyURL)
-
 		c := *conf
 		var buf []byte
 		buf, err = json.Marshal(&c)


### PR DESCRIPTION
This information is redundant with the info page provided by Agent 6 and it caused a panic on start because the URL was missing. Let's just drop it.