### PR TITLE
Bump datadog-agent version to include fargate fixes

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -13,7 +13,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 6e745e434a3b0308644ffc3f34f7fc2f13c3f069
+  version: c2c32c7b0770ffe6d819095df0eaee959717a48a
   subpackages:
   - pkg/config
   - pkg/diagnose/diagnosis

--- a/gorake.rb
+++ b/gorake.rb
@@ -25,7 +25,7 @@ def go_build(program, opts={})
   agentversion = ENV["PROCESS_AGENT_VERSION"] || "0.99.0"
 
   # NOTE: This value is currently hardcoded and needs to be manually incremented during release
-  winversion = "6.1.0".split(".")
+  winversion = "6.1.1".split(".")
 
   vars = {}
   vars["#{dd}.Version"] = agentversion


### PR DESCRIPTION
Includes: https://github.com/DataDog/datadog-agent/commit/c2c32c7b0770ffe6d819095df0eaee959717a48a

Also bumping windows version to 6.1.1