### PR TITLE
Move docker errors to DEBUG level

### DIFF
--- a/util/container/container.go
+++ b/util/container/container.go
@@ -88,7 +88,7 @@ func GetContainers() ([]*docker.Container, error) {
 	}
 
 	for _, e := range errs {
-		log.Error(e)
+		log.Debug(e)
 	}
 
 	return containers, errors.New("failed to get containers from any source")


### PR DESCRIPTION
We've had multiple complaints where folks are seeing docker-related
errors when they either (a) don't run docker at all or (b) have a docker
socket available but don't care about docker monitoring. By moving this
DEBUG we cut down on noise.

The trade-off is potentially missing an
error when someone _does_ care about docker - but in those cases we will
have support folks as for DEBUG-level logs.