### PR TITLE
Moises.botarro/better handling wildcards data scrubber

### DIFF
--- a/config/data_scrubber.go
+++ b/config/data_scrubber.go
@@ -44,13 +44,13 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 
 	for _, word := range words {
 		if forbiddenSymbols.MatchString(word) {
-			log.Warnf("data scrubber: %s not compiled. The sensitive word must "+
+			log.Warnf("data scrubber: %s skipped. The sensitive word must "+
 				"contain only alphanumeric characters, underscores or wildcards ('*')", word)
 			continue
 		}
 
 		if word == "*" {
-			log.Warnf("data scrubber: %s not compiled. The sensitive word '*' is not supported", word)
+			log.Warnf("data scrubber: ignoring wildcard-only ('*') sensitive word as it is not supported", word)
 			continue
 		}
 
@@ -62,7 +62,7 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 				if i == len(originalRunes)-1 {
 					enhancedWord.WriteString("[^ =]*")
 				} else if originalRunes[i+1] == '*' {
-					log.Warnf("data scrubber: %s not compiled. The sensitive word "+
+					log.Warnf("data scrubber: %s skipped. The sensitive word "+
 						"must not contain two consecutives '*'", word)
 					valid = false
 					break
@@ -83,7 +83,7 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 		if err == nil {
 			compiledRegexps = append(compiledRegexps, r)
 		} else {
-			log.Warnf("data scrubber: %s couldn't be compiled into a regex expression", word)
+			log.Warnf("data scrubber: %s skipped. It couldn't be compiled into a regex expression", word)
 		}
 	}
 

--- a/config/data_scrubber.go
+++ b/config/data_scrubber.go
@@ -29,16 +29,16 @@ type DataScrubber struct {
 func NewDefaultDataScrubber() *DataScrubber {
 	newDataScrubber := &DataScrubber{
 		Enabled:           true,
-		SensitivePatterns: CompileStringsToRegex(defaultSensitiveWords),
+		SensitivePatterns: compileStringsToRegex(defaultSensitiveWords),
 	}
 
 	return newDataScrubber
 }
 
-// CompileStringsToRegex compile each word in the slice into a regex pattern to match
+// compileStringsToRegex compile each word in the slice into a regex pattern to match
 // against the cmdline arguments
 // The word must contain only word characters ([a-zA-z0-9_]) or wildcards *
-func CompileStringsToRegex(words []string) []*regexp.Regexp {
+func compileStringsToRegex(words []string) []*regexp.Regexp {
 	compiledRegexps := make([]*regexp.Regexp, 0, len(words))
 	forbiddenSymbols := regexp.MustCompile("[^a-zA-Z0-9_*]")
 
@@ -114,6 +114,6 @@ func (ds *DataScrubber) ScrubCmdline(cmdline []string) []string {
 
 // AddCustomSensitiveWords adds custom sensitive words on the DataScrubber object
 func (ds *DataScrubber) AddCustomSensitiveWords(words []string) {
-	newPatterns := CompileStringsToRegex(words)
+	newPatterns := compileStringsToRegex(words)
 	ds.SensitivePatterns = append(ds.SensitivePatterns, newPatterns...)
 }

--- a/config/data_scrubber.go
+++ b/config/data_scrubber.go
@@ -57,7 +57,6 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 		originalRunes := []rune(word)
 		var enhancedWord bytes.Buffer
 		valid := true
-
 		for i, rune := range originalRunes {
 			if rune == '*' {
 				if i == len(originalRunes)-1 {

--- a/config/data_scrubber.go
+++ b/config/data_scrubber.go
@@ -67,7 +67,7 @@ func compileStringsToRegex(words []string) []*regexp.Regexp {
 					valid = false
 					break
 				} else {
-					enhancedWord.WriteString(fmt.Sprintf("[^%c\\s]*", word[i+1]))
+					enhancedWord.WriteString(fmt.Sprintf("[^\\s=]*"))
 				}
 			} else {
 				enhancedWord.WriteString(string(rune))

--- a/config/data_scrubber.go
+++ b/config/data_scrubber.go
@@ -60,14 +60,14 @@ func compileStringsToRegex(words []string) []*regexp.Regexp {
 		for i, rune := range originalRunes {
 			if rune == '*' {
 				if i == len(originalRunes)-1 {
-					enhancedWord.WriteString("[^ =]*")
+					enhancedWord.WriteString("[^ =:]*")
 				} else if originalRunes[i+1] == '*' {
 					log.Warnf("data scrubber: %s skipped. The sensitive word "+
 						"must not contain two consecutives '*'", word)
 					valid = false
 					break
 				} else {
-					enhancedWord.WriteString(fmt.Sprintf("[^\\s=]*"))
+					enhancedWord.WriteString(fmt.Sprintf("[^\\s=:$/]*"))
 				}
 			} else {
 				enhancedWord.WriteString(string(rune))
@@ -78,7 +78,7 @@ func compileStringsToRegex(words []string) []*regexp.Regexp {
 			continue
 		}
 
-		pattern := "(?P<key>( +| -{1,2})(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=)(?P<value>[^\\s]*)"
+		pattern := "(?P<key>( +| -{1,2})(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=|:)(?P<value>[^\\s]*)"
 		r, err := regexp.Compile(pattern)
 		if err == nil {
 			compiledRegexps = append(compiledRegexps, r)

--- a/config/data_scrubber.go
+++ b/config/data_scrubber.go
@@ -49,9 +49,15 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 			continue
 		}
 
+		if word == "*" {
+			log.Warnf("data scrubber: %s not compiled. The sensitive word '*' is not supported", word)
+			continue
+		}
+
 		originalRunes := []rune(word)
 		var enhancedWord bytes.Buffer
 		valid := true
+
 		for i, rune := range originalRunes {
 			if rune == '*' {
 				if i == len(originalRunes)-1 {
@@ -62,7 +68,7 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 					valid = false
 					break
 				} else {
-					enhancedWord.WriteString(fmt.Sprintf("[^%c]*", word[i+1]))
+					enhancedWord.WriteString(fmt.Sprintf("[^%c\\s]*", word[i+1]))
 				}
 			} else {
 				enhancedWord.WriteString(string(rune))
@@ -73,7 +79,7 @@ func CompileStringsToRegex(words []string) []*regexp.Regexp {
 			continue
 		}
 
-		pattern := "(?P<key>( +|-)(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=)(?P<value>[^\\s]*)"
+		pattern := "(?P<key>( +| -{1,2})(?i)" + enhancedWord.String() + ")(?P<delimiter> +|=)(?P<value>[^\\s]*)"
 		r, err := regexp.Compile(pattern)
 		if err == nil {
 			compiledRegexps = append(compiledRegexps, r)

--- a/config/data_scrubber_test.go
+++ b/config/data_scrubber_test.go
@@ -12,11 +12,13 @@ func setupDataScrubber(t *testing.T) *DataScrubber {
 		"consul_token",
 		"dd_password",
 		"blocked_from_yaml",
+		"config",
+		"pid",
 	}
 
 	expectedPatterns := make([]string, 0, len(defaultSensitiveWords)+len(customSensitiveWords))
 	for _, word := range append(defaultSensitiveWords, customSensitiveWords...) {
-		expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)"+word+")(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+		expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)"+word+")(?P<delimiter> +|=)(?P<value>[^\\s]*)")
 	}
 
 	scrubber := NewDefaultDataScrubber()
@@ -41,40 +43,17 @@ func setupDataScrubberWildCard(t *testing.T) *DataScrubber {
 
 	expectedPatterns := make([]string, 0, len(defaultSensitiveWords))
 	for _, word := range append(defaultSensitiveWords) {
-		expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)"+word+")(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+		expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)"+word+")(?P<delimiter> +|=)(?P<value>[^\\s]*)")
 	}
 
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^b]*befpass)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)afterpass[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^b]*both[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)mi[^l]*le)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^p]*pass[^d]*d[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)[^b\\s]*befpass)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)afterpass[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)[^b\\s]*both[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)mi[^l\\s]*le)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)[^p\\s]*pass[^d\\s]*d[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
 
 	scrubber := NewDefaultDataScrubber()
 	scrubber.AddCustomSensitiveWords(wildcards)
-
-	assert.Equal(t, true, scrubber.Enabled)
-	for i, pattern := range scrubber.SensitivePatterns {
-		assert.Equal(t, expectedPatterns[i], fmt.Sprint(pattern))
-	}
-
-	return scrubber
-}
-
-func setupDataScrubberMatchAll(t *testing.T) *DataScrubber {
-	matchAll := []string{
-		"*",
-	}
-
-	expectedPatterns := make([]string, 0, len(defaultSensitiveWords))
-	for _, word := range append(defaultSensitiveWords) {
-		expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)"+word+")(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	}
-
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-
-	scrubber := NewDefaultDataScrubber()
-	scrubber.AddCustomSensitiveWords(matchAll)
 
 	assert.Equal(t, true, scrubber.Enabled)
 	for i, pattern := range scrubber.SensitivePatterns {
@@ -117,21 +96,19 @@ func TestUncompilableWord(t *testing.T) {
 		"after*",
 		"*both*",
 		"mi*le",
-		"*",
 		"*pass*d*",
 	}
 
 	expectedPatterns := make([]string, 0, len(defaultSensitiveWords)+len(validCustomSenstiveWords))
 	for _, word := range append(defaultSensitiveWords, validCustomSenstiveWords...) {
-		expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)"+word+")(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+		expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)"+word+")(?P<delimiter> +|=)(?P<value>[^\\s]*)")
 	}
 
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^b]*bef)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)after[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^b]*both[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)mi[^l]*le)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
-	expectedPatterns = append(expectedPatterns, "(?P<key>( +|-)(?i)[^p]*pass[^d]*d[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)[^b\\s]*bef)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)after[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)[^b\\s]*both[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)mi[^l\\s]*le)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
+	expectedPatterns = append(expectedPatterns, "(?P<key>( +| -{1,2})(?i)[^p\\s]*pass[^d\\s]*d[^ =]*)(?P<delimiter> +|=)(?P<value>[^\\s]*)")
 
 	scrubber := NewDefaultDataScrubber()
 	scrubber.AddCustomSensitiveWords(customSensitiveWords)
@@ -163,6 +140,9 @@ func TestBlacklistedArgs(t *testing.T) {
 		{[]string{"agent", "--PASSword", "1234"}, []string{"agent", "--PASSword", "********"}},
 		{[]string{"agent", "--PaSsWoRd=1234"}, []string{"agent", "--PaSsWoRd=********"}},
 		{[]string{"java -password      1234"}, []string{"java", "-password", "", "", "", "", "", "********"}},
+		{[]string{"process-agent --config=datadog.yaml --pid=process-agent.pid"}, []string{"process-agent", "--config=********", "--pid=********"}},
+		{[]string{"1-password --config=12345"}, []string{"1-password", "--config=********"}},
+		{[]string{"java kafka password 1234"}, []string{"java", "kafka", "password", "********"}},
 	}
 
 	scrubber := setupDataScrubber(t)
@@ -271,30 +251,13 @@ func TestMatchWildCards(t *testing.T) {
 		{[]string{"spidly   --passwd=1234   password   1234   -mypassword   1234   --passwords=12345,123456   --mypasswords=1234,123456"},
 			[]string{"spidly", "", "", "--passwd=********", "", "", "password", "", "", "********", "", "", "-mypassword", "", "", "********",
 				"", "", "--passwords=********", "", "", "--mypasswords=********"}},
+
+		{[]string{"run-middle password 12345"}, []string{"run-middle", "password", "********"}},
+		{[]string{"generate-password -password 12345"}, []string{"generate-password", "-password", "********"}},
+		{[]string{"generate-password --password=12345"}, []string{"generate-password", "--password=********"}},
 	}
 
 	scrubber := setupDataScrubberWildCard(t)
-
-	for i := range cases {
-		cases[i].cmdline = scrubber.ScrubCmdline(cases[i].cmdline)
-		assert.Equal(t, cases[i].parsedCmdline, cases[i].cmdline)
-	}
-}
-
-func TestMatchAll(t *testing.T) {
-	cases := []struct {
-		cmdline       []string
-		parsedCmdline []string
-	}{
-		{[]string{"run", "password", "1234", "-admin", "admin", "--key=1234"},
-			[]string{"run", "password", "********", "-admin", "********", "--key=********"}},
-		{[]string{"run password 1234 -admin admin --key=1234"},
-			[]string{"run", "password", "********", "-admin", "********", "--key=********"}},
-		{[]string{"run   password   1234   -admin   admin   --key=1234"},
-			[]string{"run", "", "", "password", "", "", "********", "", "", "-admin", "", "", "********", "", "", "--key=********"}},
-	}
-
-	scrubber := setupDataScrubberMatchAll(t)
 
 	for i := range cases {
 		cases[i].cmdline = scrubber.ScrubCmdline(cases[i].cmdline)

--- a/config/data_scrubber_test.go
+++ b/config/data_scrubber_test.go
@@ -194,7 +194,6 @@ func TestNoBlacklistedArgs(t *testing.T) {
 		cases[i].cmdline = scrubber.ScrubCmdline(cases[i].cmdline)
 		assert.Equal(t, cases[i].parsedCmdline, cases[i].cmdline)
 	}
-
 }
 
 func TestMatchWildCards(t *testing.T) {

--- a/config/data_scrubber_test.go
+++ b/config/data_scrubber_test.go
@@ -240,6 +240,9 @@ func TestMatchWildCards(t *testing.T) {
 		{[]string{"run-middle password 12345"}, []string{"run-middle", "password", "********"}},
 		{[]string{"generate-password -password 12345"}, []string{"generate-password", "-password", "********"}},
 		{[]string{"generate-password --password=12345"}, []string{"generate-password", "--password=********"}},
+
+		{[]string{"java /var/lib/datastax-agent/conf/address.yaml -Dopscenter.ssl.keyStorePassword=opscenter -Dagent-pidfile=/var/run/datastax-agent/datastax-agent.pid --anotherpassword=1234"},
+			[]string{"java", "/var/lib/datastax-agent/conf/address.yaml", "-Dopscenter.ssl.keyStorePassword=********", "-Dagent-pidfile=/var/run/datastax-agent/datastax-agent.pid", "--anotherpassword=********"}},
 	}
 
 	scrubber := setupDataScrubberWildCard(t)
@@ -259,7 +262,7 @@ var avoidOptimization []string
 
 func benchmarkRegexMatching(nbProcesses int, b *testing.B) {
 	runningProcesses := make([][]string, nbProcesses)
-	foolCmdline := []string{"python ~/test/run.py --password=1234 -password 1234 -password=admin -open_password 2345 -consul=1234 -p 2808 &"}
+	foolCmdline := []string{"python ~/test/run.py --password=1234 -password 1234 -password=admin -secret 2345 -credentials=1234 -api_key 2808 &"}
 
 	customSensitiveWords := []string{
 		"consul_token",


### PR DESCRIPTION
@DataDog/burrito 
This PR prevent the user from using '*' as a wildcard to match all the process arguments. 

It also fixes the bugs:

1. Matching the middle of an argument key that contains '-<sensitive_word>', as in 
1-password --config=12345 => 1-password ********

2. Matching multiple arguments as an argument key if they don't contain the next expected character. 
Example:
\*password would match all the bolded arguments on 
java **kafka.kafka dont_have letter_after_m -password** 12345  
as a key