### PR TITLE
Bumped datadog-agent commit hash to last commit

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -13,7 +13,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: c2c32c7b0770ffe6d819095df0eaee959717a48a
+  version: 60752c7af4e204e77ccfa1bc7c86541acf888502
   subpackages:
   - pkg/config
   - pkg/diagnose/diagnosis

--- a/util/util.go
+++ b/util/util.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
-	log "github.com/cihub/seelog"
 )
 
 // ErrNotImplemented is the "not implemented" error given by `gopsutil` when an
@@ -83,17 +82,6 @@ func StringInSlice(slice []string, searchString string) bool {
 		}
 	}
 	return false
-}
-
-// DockerIsAvailable returns true if Docker is available on this machine via a socket.
-func DockerIsAvailable() bool {
-	if _, err := docker.ConnectToDocker(); err != nil {
-		if err != docker.ErrDockerNotAvailable {
-			log.Warnf("unable to connect to docker: %s", err)
-		}
-		return false
-	}
-	return true
 }
 
 // GetDockerSocketPath is only for exposing the sockpath out of the module


### PR DESCRIPTION
Bumped the datadog-agent version on glide.lock file.

Since the method `ConnectToDocker` has been changed to the private one `connectToDocker`, the function that used it was deleted. 

