### PR TITLE
Changed scrub_args to *bool to better handle default value

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -127,6 +127,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal("info", agentConfig.LogLevel)
 	assert.Equal(true, agentConfig.AllowRealTime)
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
+	assert.Equal(true, agentConfig.Scrubber.Enabled)
 
 	os.Setenv("DOCKER_DD_AGENT", "yes")
 	agentConfig = NewDefaultAgentConfig()
@@ -159,6 +160,7 @@ func TestDDAgentConfigWithNewOpts(t *testing.T) {
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 	assert.Equal(20, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(true, agentConfig.Windows.AddNewArgs)
+	assert.Equal(true, agentConfig.Scrubber.Enabled)
 }
 
 func TestDDAgentConfigBothVersions(t *testing.T) {
@@ -196,6 +198,7 @@ func TestDDAgentConfigBothVersions(t *testing.T) {
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 	assert.Equal(40, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(true, agentConfig.Windows.AddNewArgs)
+	assert.Equal(true, agentConfig.Scrubber.Enabled)
 }
 
 func TestDDAgentConfigYamlOnly(t *testing.T) {
@@ -214,6 +217,7 @@ func TestDDAgentConfigYamlOnly(t *testing.T) {
 		"  windows:",
 		"    args_refresh_interval: 100",
 		"    add_new_args: false",
+		"  scrub_args: false",
 	}, "\n")), &ddy)
 	assert.NoError(err)
 
@@ -230,6 +234,7 @@ func TestDDAgentConfigYamlOnly(t *testing.T) {
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals["process"])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Windows.AddNewArgs)
+	assert.Equal(false, agentConfig.Scrubber.Enabled)
 
 	ddy = YamlAgentConfig{}
 	err = yaml.Unmarshal([]byte(strings.Join([]string{
@@ -245,6 +250,7 @@ func TestDDAgentConfigYamlOnly(t *testing.T) {
 		"  windows:",
 		"    args_refresh_interval: -1",
 		"    add_new_args: true",
+		"  scrub_args: true",
 	}, "\n")), &ddy)
 	assert.NoError(err)
 
@@ -256,6 +262,7 @@ func TestDDAgentConfigYamlOnly(t *testing.T) {
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 	assert.Equal(-1, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(true, agentConfig.Windows.AddNewArgs)
+	assert.Equal(true, agentConfig.Scrubber.Enabled)
 
 	ddy = YamlAgentConfig{}
 	err = yaml.Unmarshal([]byte(strings.Join([]string{
@@ -279,6 +286,7 @@ func TestDDAgentConfigYamlOnly(t *testing.T) {
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
 	assert.Equal(15, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(true, agentConfig.Windows.AddNewArgs)
+	assert.Equal(true, agentConfig.Scrubber.Enabled)
 }
 
 func TestProxyEnv(t *testing.T) {

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -42,6 +42,7 @@ type YamlAgentConfig struct {
 		// A list of regex patterns that will exclude a process if matched.
 		BlacklistPatterns []string `yaml:"blacklist_patterns"`
 		// Enable/Disable the DataScrubber to obfuscate process args
+		// XXX: Using a bool pointer to differentiate between empty and set.
 		ScrubArgs *bool `yaml:"scrub_args,omitempty"`
 		// A custom word list to enhance the default one used by the DataScrubber
 		CustomSensitiveWords []string `yaml:"custom_sensitive_words"`

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -42,7 +42,7 @@ type YamlAgentConfig struct {
 		// A list of regex patterns that will exclude a process if matched.
 		BlacklistPatterns []string `yaml:"blacklist_patterns"`
 		// Enable/Disable the DataScrubber to obfuscate process args
-		ScrubArgs bool `yaml:"scrub_args"`
+		ScrubArgs *bool `yaml:"scrub_args,omitempty"`
 		// A custom word list to enhance the default one used by the DataScrubber
 		CustomSensitiveWords []string `yaml:"custom_sensitive_words"`
 		// How many check results to buffer in memory when POST fails. The default is usually fine.
@@ -75,7 +75,8 @@ func NewYamlIfExists(configPath string) (*YamlAgentConfig, error) {
 	var yamlConf YamlAgentConfig
 
 	// Set default values for booleans otherwise it will default to false.
-	yamlConf.Process.ScrubArgs = true
+	defaultScrubArgs := true
+	yamlConf.Process.ScrubArgs = &defaultScrubArgs
 	defaultNewArgs := true
 	yamlConf.Process.Windows.AddNewArgs = &defaultNewArgs
 
@@ -144,7 +145,9 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 	agentConf.Blacklist = blacklist
 
 	// DataScrubber
-	agentConf.Scrubber.Enabled = yc.Process.ScrubArgs
+	if yc.Process.ScrubArgs != nil {
+		agentConf.Scrubber.Enabled = *yc.Process.ScrubArgs
+	}
 	agentConf.Scrubber.AddCustomSensitiveWords(yc.Process.CustomSensitiveWords)
 
 	if yc.Process.QueueSize > 0 {

--- a/glide.lock
+++ b/glide.lock
@@ -13,7 +13,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 60752c7af4e204e77ccfa1bc7c86541acf888502
+  version: 36d023d053e8705c449b9e12dbeaa1feb0529ce7
   subpackages:
   - pkg/config
   - pkg/diagnose/diagnosis


### PR DESCRIPTION
@DataDog/burrito 
Changed `scrub_args` field on yaml file to *bool and tagged it with "omitempty" to assure that default value is set to true even though the field isn't present in the yaml file.
Added some tests.