### PR TITLE
Added environment variables to control process args scrubbing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -411,6 +411,17 @@ func mergeEnv(c *AgentConfig) *AgentConfig {
 		}
 	}
 
+	// Process Arguments Scrubbing
+	if enabled, err := isAffirmative(os.Getenv("DD_SCRUB_ARGS")); enabled {
+		c.Scrubber.Enabled = true
+	} else if !enabled && err == nil {
+		c.Scrubber.Enabled = false
+	}
+
+	if v := os.Getenv("DD_CUSTOM_SENSITIVE_WORDS"); v != "" {
+		c.Scrubber.AddCustomSensitiveWords(strings.Split(v, ","))
+	}
+
 	if v := os.Getenv("DD_AGENT_PY"); v != "" {
 		c.DDAgentPy = v
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,7 +79,6 @@ func TestOnlyEnvConfig(t *testing.T) {
 }
 
 func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {
-	os.Setenv("DD_SCRUB_ARGS", "true")
 	os.Setenv("DD_CUSTOM_SENSITIVE_WORDS", "*password*,consul_token,*api_key")
 
 	agentConfig, _ := NewAgentConfig(nil, nil)
@@ -89,8 +88,10 @@ func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {
 		cmdline       []string
 		parsedCmdline []string
 	}{
-		{[]string{"spidly", "--mypasswords=123,456", "consul_token", "1234", "--dd_api_key=1234"},
-			[]string{"spidly", "--mypasswords=********", "consul_token", "********", "--dd_api_key=********"}},
+		{
+			[]string{"spidly", "--mypasswords=123,456", "consul_token", "1234", "--dd_api_key=1234"},
+			[]string{"spidly", "--mypasswords=********", "consul_token", "********", "--dd_api_key=********"},
+		},
 	}
 
 	for i := range cases {
@@ -98,7 +99,6 @@ func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {
 		assert.Equal(t, cases[i].parsedCmdline, cases[i].cmdline)
 	}
 
-	os.Setenv("DD_SCRUB_ARGS", "")
 	os.Setenv("DD_CUSTOM_SENSITIVE_WORDS", "")
 }
 
@@ -113,8 +113,10 @@ func TestOnlyEnvConfigArgsScrubbingDisabled(t *testing.T) {
 		cmdline       []string
 		parsedCmdline []string
 	}{
-		{[]string{"spidly", "--mypasswords=123,456", "consul_token", "1234", "--dd_api_key=1234"},
-			[]string{"spidly", "--mypasswords=123,456", "consul_token", "1234", "--dd_api_key=1234"}},
+		{
+			[]string{"spidly", "--mypasswords=123,456", "consul_token", "1234", "--dd_api_key=1234"},
+			[]string{"spidly", "--mypasswords=123,456", "consul_token", "1234", "--dd_api_key=1234"},
+		},
 	}
 
 	for i := range cases {


### PR DESCRIPTION
@DataDog/burrito 

Added the possibility to set the data scrubber behavior using environment variables. This is useful when we don't configure the Agent using a conf or yaml file like when deploying it in kubernetes nodes. 