### PR TITLE
[proc] return 0 rate if previous value is 0

### DIFF
--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -147,7 +147,7 @@ func fmtProcessStats(
 func calculateRate(cur, prev uint64, before time.Time) float32 {
 	now := time.Now()
 	diff := now.Unix() - before.Unix()
-	if before.IsZero() || diff <= 0 {
+	if before.IsZero() || diff <= 0 || prev == 0 {
 		return 0
 	}
 	return float32(cur-prev) / float32(diff)

--- a/checks/process_test.go
+++ b/checks/process_test.go
@@ -125,6 +125,17 @@ func TestPercentCalculation(t *testing.T) {
 	}
 }
 
+func TestRateCalculation(t *testing.T) {
+	now := time.Now()
+	prev := now.Add(-1 * time.Second)
+	var empty time.Time
+	assert.True(t, floatEquals(calculateRate(5, 1, prev), 4))
+	assert.True(t, floatEquals(calculateRate(5, 1, prev.Add(-2*time.Second)), float32(1.33333333)))
+	assert.True(t, floatEquals(calculateRate(5, 1, now), 0))
+	assert.True(t, floatEquals(calculateRate(5, 0, prev), 0))
+	assert.True(t, floatEquals(calculateRate(5, 1, empty), 0))
+}
+
 func floatEquals(a, b float32) bool {
 	var e float32 = 0.00000001 // Difference less than some epsilon
 	return a-b < e && b-a < e


### PR DESCRIPTION
Return 0 if previous value is 0 while calculating the rate.

This is an attempt to fix the problem of getting really large network tx/rx rate on containers. @DataDog/burrito 