### PR TITLE
Adding option to strip all command arguments

### DIFF
--- a/checks/process.go
+++ b/checks/process.go
@@ -127,13 +127,13 @@ func fmtProcesses(
 			continue
 		}
 
-		// Hide blacklisted args if the Scrubber is enabled
-		fp.Cmdline = cfg.Scrubber.ScrubProcessCommand(fp)
-
 		ctr, ok := ctrByPid[fp.Pid]
 		if !ok {
 			ctr = docker.NullContainer
 		}
+
+		// Hide blacklisted args if the Scrubber is enabled
+		fp.Cmdline = cfg.Scrubber.ScrubProcessCommand(fp)
 
 		chunk = append(chunk, &model.Process{
 			Pid:                    fp.Pid,

--- a/config/config.go
+++ b/config/config.go
@@ -271,6 +271,7 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig) (*AgentConfig, e
 		cfg.Scrubber.Enabled = agentIni.GetBool(ns, "scrub_args", true)
 		customSensitiveWords := agentIni.GetStrArrayDefault(ns, "custom_sensitive_words", ",", []string{})
 		cfg.Scrubber.AddCustomSensitiveWords(customSensitiveWords)
+		cfg.Scrubber.StripAllArguments = agentIni.GetBool(ns, "strip_proc_arguments", false)
 
 		procLimit := agentIni.GetIntDefault(ns, "proc_limit", cfg.ProcLimit)
 		if procLimit <= maxProcLimit {
@@ -420,6 +421,9 @@ func mergeEnv(c *AgentConfig) *AgentConfig {
 
 	if v := os.Getenv("DD_CUSTOM_SENSITIVE_WORDS"); v != "" {
 		c.Scrubber.AddCustomSensitiveWords(strings.Split(v, ","))
+	}
+	if ok, _ := isAffirmative(os.Getenv("DD_STRIP_PROCESS_ARGS")); ok {
+		c.Scrubber.StripAllArguments = true
 	}
 
 	if v := os.Getenv("DD_AGENT_PY"); v != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/gopsutil/process"
 	"github.com/go-ini/ini"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -95,7 +96,7 @@ func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {
 	}
 
 	for i := range cases {
-		cases[i].cmdline, _ = agentConfig.Scrubber.scrubCmdline(cases[i].cmdline)
+		cases[i].cmdline, _ = agentConfig.Scrubber.scrubCommand(cases[i].cmdline)
 		assert.Equal(t, cases[i].parsedCmdline, cases[i].cmdline)
 	}
 
@@ -120,7 +121,8 @@ func TestOnlyEnvConfigArgsScrubbingDisabled(t *testing.T) {
 	}
 
 	for i := range cases {
-		cases[i].cmdline, _ = agentConfig.Scrubber.scrubCmdline(cases[i].cmdline)
+		fp := &process.FilledProcess{Cmdline: cases[i].cmdline}
+		cases[i].cmdline = agentConfig.Scrubber.ScrubProcessCommand(fp)
 		assert.Equal(t, cases[i].parsedCmdline, cases[i].cmdline)
 	}
 

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-process-agent/util/container"
 )
 
-// YamlAgentConfig is a sturcutre used for marshaling the datadog.yaml configuratio
+// YamlAgentConfig is a structure used for marshaling the datadog.yaml configuration
 // available in Agent versions >= 6
 type YamlAgentConfig struct {
 	APIKey string `yaml:"api_key"`
@@ -46,6 +46,8 @@ type YamlAgentConfig struct {
 		ScrubArgs *bool `yaml:"scrub_args,omitempty"`
 		// A custom word list to enhance the default one used by the DataScrubber
 		CustomSensitiveWords []string `yaml:"custom_sensitive_words"`
+		// Strips all process arguments
+		StripProcessArguments bool `yaml:"strip_proc_arguments"`
 		// How many check results to buffer in memory when POST fails. The default is usually fine.
 		QueueSize int `yaml:"queue_size"`
 		// The maximum number of file descriptors to open when collecting net connections.
@@ -150,6 +152,9 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 		agentConf.Scrubber.Enabled = *yc.Process.ScrubArgs
 	}
 	agentConf.Scrubber.AddCustomSensitiveWords(yc.Process.CustomSensitiveWords)
+	if yc.Process.StripProcessArguments {
+		agentConf.Scrubber.StripAllArguments = yc.Process.StripProcessArguments
+	}
 
 	if yc.Process.QueueSize > 0 {
 		agentConf.QueueSize = yc.Process.QueueSize


### PR DESCRIPTION
Adding a `.yaml`, `.ini`, and environment flag config to strip all command arguments from process commands.

`strip_proc_arguments: true` or `DD_STRIP_PROCESS_ARGS=true ./process-agent`

`6.3.1` is branched off of the tag `6.3.0`. I'll cherry-pick this commit into master after it is merged.

Gist showing output of the `check` command locally in a vagrant session:
https://gist.github.com/sunhay/6821b245005c9c14ad3e2b74b5a34b9a

@DataDog/burrito 