### PR TITLE
Support additional endpoints in the Agent

### DIFF
--- a/agent/collector_test.go
+++ b/agent/collector_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-process-agent/config"
+	"github.com/DataDog/datadog-process-agent/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateRTStatus(t *testing.T) {
+	assert := assert.New(t)
+	cfg := config.NewDefaultAgentConfig()
+	c, err := NewCollector(cfg)
+	assert.NoError(err)
+	// XXX: Give the collector a big channel so it never blocks.
+	c.rtIntervalCh = make(chan time.Duration, 1000)
+
+	// Validate that we switch to real-time if only one response says so.
+	statuses := []*model.CollectorStatus{
+		{ActiveClients: 0, Interval: 2},
+		{ActiveClients: 3, Interval: 2},
+		{ActiveClients: 0, Interval: 2},
+	}
+	c.updateStatus(statuses)
+	assert.Equal(int64(1), atomic.LoadInt64(&c.realTimeEnabled))
+
+	// Validate that we stay that way
+	statuses = []*model.CollectorStatus{
+		{ActiveClients: 0, Interval: 2},
+		{ActiveClients: 3, Interval: 2},
+		{ActiveClients: 0, Interval: 2},
+	}
+	c.updateStatus(statuses)
+	assert.Equal(int64(1), atomic.LoadInt64(&c.realTimeEnabled))
+
+	// And that it can turn back off
+	statuses = []*model.CollectorStatus{
+		{ActiveClients: 0, Interval: 2},
+		{ActiveClients: 0, Interval: 2},
+		{ActiveClients: 0, Interval: 2},
+	}
+	c.updateStatus(statuses)
+	assert.Equal(int64(0), atomic.LoadInt64(&c.realTimeEnabled))
+}
+
+func TestUpdateRTInterval(t *testing.T) {
+	assert := assert.New(t)
+	cfg := config.NewDefaultAgentConfig()
+	c, err := NewCollector(cfg)
+	assert.NoError(err)
+	// XXX: Give the collector a big channel so it never blocks.
+	c.rtIntervalCh = make(chan time.Duration, 1000)
+
+	// Validate that we pick the largest interval.
+	statuses := []*model.CollectorStatus{
+		{ActiveClients: 0, Interval: 3},
+		{ActiveClients: 3, Interval: 2},
+		{ActiveClients: 0, Interval: 10},
+	}
+	c.updateStatus(statuses)
+	assert.Equal(int64(1), atomic.LoadInt64(&c.realTimeEnabled))
+	assert.Equal(10*time.Second, c.realTimeInterval)
+}


### PR DESCRIPTION
Both Agent 5 and 6 configuration support additional endpoints.
  - Agent 5 config actually uses all the api keys provided now.
  - Agent 6 has the same format as datadog.yaml but under the `process`
  namespace.
- When we POST the collector will run concurrent requests to limit any
impact on collection latency.

See test cases for example config