### PR TITLE
Optionally build eBPF-enabled tracer if agent build with EBPF=true

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,8 @@ task :build do
     :race => ENV['GO_RACE'] == 'true',
     :add_build_vars => ENV['PROCESS_AGENT_ADD_BUILD_VARS'] != 'false',
     :static => ENV['PROCESS_AGENT_STATIC'] == 'true',
-    :os => os
+    :os => os,
+    :bpf => ENV['EBPF'] == 'true'
   })
 end
 

--- a/glide.lock
+++ b/glide.lock
@@ -184,7 +184,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/DataDog/tcptracer-bpf
-  version: f080eefea3eee677dd65e986b1ab5ba044eedae7
+  version: 53ac204431e1bbeb7a08ef5c0177da0b1a46cd55
 - name: github.com/spf13/viper
   version: aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5
 - name: github.com/StackExchange/wmi

--- a/gorake.rb
+++ b/gorake.rb
@@ -41,7 +41,9 @@ def go_build(program, opts={})
   cmd = opts[:cmd]
   cmd += ' -race' if opts[:race]
   if os != "windows"
-    cmd += ' -tags \'docker kubelet kubeapiserver\''
+    tag_set = 'docker kubelet kubeapiserver' # Default tags for non-windows OSes (e.g. linux)
+    tag_set += ' linux_bpf' if opts[:bpf]   # Add BPF if ebpf exists
+    cmd += " -tags \'#{tag_set}\'"
   end
   print "cmd"
 


### PR DESCRIPTION
Small change to improve our build process.

To build the agent with the eBPF network tracer, it needs to have the build tag `linux_bpf`. This requires an option to be added to our rake commands as well (`EBPF=true`)

```
$ rake build

cmdgo build -a -o process-agent -tags 'docker kubelet kubeapiserver' -ldflags "-X 'main.Version=0.99.0' -X 'main.BuildDate=2018-06-28T19:11:04+0000' -X 'main.GitCommit=5c48a6d' -X 'main.GitBranch=master' -X 'main.GoVersion=go version go1.9.1 linux/amd64'" github.com/DataDog/datadog-process-agent/agent
```

```
$ rake build EBPF=true

cmdgo build -a -o process-agent -tags 'docker kubelet kubeapiserver linux_bpf' -ldflags "-X 'main.Version=0.99.0' -X 'main.BuildDate=2018-06-28T19:12:22+0000' -X 'main.GitCommit=5c48a6d' -X 'main.GitBranch=master' -X 'main.GoVersion=go version go1.9.1 linux/amd64'" github.com/DataDog/datadog-process-agent/agent
```

@DataDog/burrito 