### PR TITLE
Updating build image and scripts to support configurable eBPF-support

### DIFF
--- a/gorake.rb
+++ b/gorake.rb
@@ -53,6 +53,8 @@ def go_build(program, opts={})
     ENV['CC'] = '/usr/local/musl/bin/musl-gcc'
     ldflags << '-linkmode external'
     ldflags << '-extldflags \'-static\''
+    # Since we're using musl, we need to explicitly include the linux headers when compiling for eBPF
+    ENV['CGO_CFLAGS'] = '-I/kernel-headers/include/' if opts[:bpf]
   end
   if ENV['windres'] then
     # first compile the message table, as it's an input to the resource file

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -27,9 +27,9 @@ RUN wget http://downloads.sourceforge.net/project/s3tools/s3cmd/1.5.2/s3cmd-1.5.
 RUN curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && \
     chmod +x /usr/local/bin/gimme
 
-RUN wget http://www.musl-libc.org/releases/musl-1.1.10.tar.gz && \
-    tar -xvf musl-1.1.10.tar.gz && \
-    cd musl-1.1.10 && ./configure && make && make install
+RUN wget http://www.musl-libc.org/releases/musl-1.1.19.tar.gz && \
+    tar -xvf musl-1.1.19.tar.gz && \
+    cd musl-1.1.19 && ./configure && make && make install
 
 COPY setup_linux_headers.sh /
 RUN chmod u+x setup_linux_headers.sh

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -qq -y software-properties-common && \
     apt-add-repository ppa:brightbox/ruby-ng && \
     apt-get update && \
-    apt-get install -y build-essential debhelper git gnupg rake curl devscripts ruby-dev zlib1g-dev libxml2-dev wget rpm debsigs expect ruby2.3 ruby2.3-dev createrepo python-dateutil python-dev
+    apt-get install -y build-essential debhelper git gnupg rake curl devscripts ruby-dev zlib1g-dev libxml2-dev wget rpm debsigs expect ruby2.3 ruby2.3-dev createrepo python-dateutil python-dev 
+RUN apt-get install -y linux-headers-generic
 
 RUN gem install deb-s3 inifile
 
@@ -29,6 +30,10 @@ RUN curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci
 RUN wget http://www.musl-libc.org/releases/musl-1.1.10.tar.gz && \
     tar -xvf musl-1.1.10.tar.gz && \
     cd musl-1.1.10 && ./configure && make && make install
+
+COPY setup_linux_headers.sh /
+RUN chmod u+x setup_linux_headers.sh
+RUN /setup_linux_headers.sh
 
 ENV GOPATH=/go
 ENV PATH=/go/bin:$PATH

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -5,16 +5,19 @@
 # Used by Jenkins to build process-agent package
 #
 
-FROM quay.io/datadog/jenkins-slave
+FROM quay.io/datadog/jenkins-slave:xenial
 
 MAINTAINER Shang Wang <shang.wang@datadoghq.com>
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -qq -y software-properties-common && \
     apt-add-repository ppa:brightbox/ruby-ng && \
     apt-get update && \
     apt-get install -y build-essential debhelper git gnupg rake curl devscripts ruby-dev zlib1g-dev libxml2-dev wget rpm debsigs expect ruby2.3 ruby2.3-dev createrepo python-dateutil python-dev
-RUN gem install deb-s3 fpm inifile
+
+RUN gem install deb-s3 inifile
 
 RUN wget http://downloads.sourceforge.net/project/s3tools/s3cmd/1.5.2/s3cmd-1.5.2.tar.gz && \
 	tar -xzvf s3cmd-1.5.2.tar.gz && \
@@ -25,7 +28,7 @@ RUN curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci
 
 RUN wget http://www.musl-libc.org/releases/musl-1.1.10.tar.gz && \
     tar -xvf musl-1.1.10.tar.gz && \
-    cd musl-1.1.10 && ./configure && make && sudo make install
+    cd musl-1.1.10 && ./configure && make && make install
 
 ENV GOPATH=/go
 ENV PATH=/go/bin:$PATH

--- a/packaging/build_ddagent_release.sh
+++ b/packaging/build_ddagent_release.sh
@@ -24,12 +24,6 @@ fi
 
 echo "Building Agent v$PROCESS_AGENT_VERSION to $FILENAME"
 
-echo `hostname`
-echo `uname -r`
-echo `pwd`
-echo `ls /lib/modules/`
-echo `ls /usr/src/`
-
 # Expects gimme to be installed
 eval "$(gimme 1.10.1)"
 

--- a/packaging/build_ddagent_release.sh
+++ b/packaging/build_ddagent_release.sh
@@ -24,6 +24,12 @@ fi
 
 echo "Building Agent v$PROCESS_AGENT_VERSION to $FILENAME"
 
+echo `hostname`
+echo `uname -r`
+echo `pwd`
+echo `ls /lib/modules/`
+echo `ls /usr/src/`
+
 # Expects gimme to be installed
 eval "$(gimme 1.10.1)"
 
@@ -39,7 +45,7 @@ go get github.com/Masterminds/glide
 glide install
 
 echo "Building binaries..."
-PROCESS_AGENT_STATIC=true rake build
+PROCESS_AGENT_STATIC=true rake build EBPF=$LINUX_EBPF
 
 cp process-agent $FILENAME 
 s3cmd sync -v ./$FILENAME s3://$AGENT_S3_BUCKET/

--- a/packaging/setup_linux_headers.sh
+++ b/packaging/setup_linux_headers.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -xe
+
+# Simplified setup of linux headers, based on build from:
+# https://github.com/richfelker/musl-cross-make/blob/master/litecross/Makefile#L266
+
+LINUX_SITE=https://cdn.kernel.org/pub/linux/kernel
+
+LINUX_KERNEL_VER=linux-4.4.10
+KERNEL_TAR="${LINUX_KERNEL_VER}.tar.xz"
+ARCH=x86
+
+HEADER_BASE_PATH=/kernel-headers
+
+mkdir -p $HEADER_BASE_PATH
+
+# Download and extract header files
+wget -c "${LINUX_SITE}/v4.x/${KERNEL_TAR}"
+tar -Jxvf $KERNEL_TAR --directory $HEADER_BASE_PATH && rm -rf $KERNEL_TAR
+
+# Install the headers
+cd "${HEADER_BASE_PATH}/${LINUX_KERNEL_VER}"
+mkdir -p /obj_kernel_headers/staged
+
+make ARCH=$ARCH O=$PWD/obj_kernel_headers INSTALL_HDR_PATH=$PWD/obj_kernel_headers/staged headers_install
+find $PWD/obj_kernel_headers/staged/include '(' -name .install -o -name ..install.cmd ')' -exec rm {} +
+
+# Final location for use in our apps
+mkdir -p $HEADER_BASE_PATH/include
+cp -R $PWD/obj_kernel_headers/staged/include/* $HEADER_BASE_PATH/include


### PR DESCRIPTION
This PR includes updates to our build image + scripts:
 - Update to xenial
 - Download & install 4.4 linux headers
 - Does **not** include support yet for `ebpf` + `musl`-based builds.
   - `ebpf`-based builds will create dynamically linked binaries.

@DataDog/burrito 