### PR TITLE
[proc] added timeout to process-agent payload send

### DIFF
--- a/agent/collector.go
+++ b/agent/collector.go
@@ -271,10 +271,7 @@ func (l *Collector) postToAPI(endpoint config.APIEndpoint, checkPath string, bod
 	req.Header.Add("X-Dd-Hostname", l.cfg.HostName)
 	req.Header.Add("X-Dd-Processagentversion", Version)
 
-	// we create a context with timeout and attach it to the http request, to make sure that it doesn't get stuck on
-	// any circumstances
-	start := time.Now()
-	ctx, cancel := context.WithTimeout(context.Background(), HTTPTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), ReqCtxTimeout)
 	defer cancel()
 	req.WithContext(ctx)
 
@@ -283,11 +280,7 @@ func (l *Collector) postToAPI(endpoint config.APIEndpoint, checkPath string, bod
 		if isHTTPTimeout(err) {
 			responses <- errResponse("Timeout detected on %s, %s", url, err)
 		} else {
-			if time.Since(start) >= HTTPTimeout {
-				responses <- errResponse("Client took too long to receive response from %s: %s", url, err)
-			} else {
-				responses <- errResponse("Error submitting payload to %s: %s", url, err)
-			}
+			responses <- errResponse("Error submitting payload to %s: %s", url, err)
 		}
 		return
 	}

--- a/agent/util.go
+++ b/agent/util.go
@@ -2,6 +2,12 @@ package main
 
 import (
 	"strings"
+	"time"
+)
+
+const (
+	// HTTPTimeout is the timeout in seconds for process-agent to send process payloads to DataDog
+	HTTPTimeout = 60 * time.Second
 )
 
 // IsTimeout returns true if the error is due to reaching the timeout limit on the http.client

--- a/agent/util.go
+++ b/agent/util.go
@@ -7,7 +7,9 @@ import (
 
 const (
 	// HTTPTimeout is the timeout in seconds for process-agent to send process payloads to DataDog
-	HTTPTimeout = 60 * time.Second
+	HTTPTimeout = 20 * time.Second
+	// ReqCtxTimeout is the timeout in seconds for process-agent to cancel POST request using context timeout
+	ReqCtxTimeout = 30 * time.Second
 )
 
 // IsTimeout returns true if the error is due to reaching the timeout limit on the http.client


### PR DESCRIPTION
Added timeout to http client and a context with timeout per request when agent sends process payloads to DataDog.  @DataDog/burrito 