### PR TITLE
Bump to 6.3.x on datadog-agent

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -13,7 +13,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 024324d3b11a6bd03b0cd502bd18be05dd8aba95
+  version: 11509728245f878b662c448fd538184b9ffc88f9
   subpackages:
   - pkg/config
   - pkg/diagnose/diagnosis

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/DataDog/datadog-process-agent
 import:
   - package: github.com/DataDog/datadog-agent
-    version: 024324d3b11a6bd03b0cd502bd18be05dd8aba95
+    version: 11509728245f878b662c448fd538184b9ffc88f9
   - package: github.com/DataDog/agent-payload
   - package: github.com/docker/docker
     version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363


### PR DESCRIPTION
6.3.x branch on datadog-agent includes some tagger fixes.