### PR TITLE
[config] Update datadog.yaml config initialization.

### DIFF
--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -214,7 +214,7 @@ func SetupDDAgentConfig(configPath string) error {
 	}
 
 	// load the configuration
-	if err := ddconfig.Datadog.ReadInConfig(); err != nil {
+	if err := ddconfig.Load(); err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}
 


### PR DESCRIPTION
This new config API added in
https://github.com/DataDog/datadog-agent/commit/5e22bb6aae27576ed3f7c36f4c7574e487c34348#diff-091ace02b49a46f55f2586cfec89a160R373
will actually load the proxy configuration from the yaml file. Since
this change the API we were using would _not_ load proxies and they were
broken.