### PR TITLE
[proc] bump datadog-agent dependecy and added a change

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -13,7 +13,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 11509728245f878b662c448fd538184b9ffc88f9
+  version: c52e5be9fdef803590eebbe42bc8970cf577268d
   subpackages:
   - pkg/config
   - pkg/diagnose/diagnosis

--- a/util/container/container.go
+++ b/util/container/container.go
@@ -29,8 +29,8 @@ func initContainerListeners() {
 // GetDefaultListeners returns the default auto-discovery listeners, for use in container retrieval
 func GetDefaultListeners() []config.Listeners {
 	l := []config.Listeners{{Name: "docker"}}
-	// If we can detect that this is a fargate instance, lets add it as well
-	if ecs.IsFargateInstance() {
+	// If we can detect that this is an ecs or fargate instance, lets add it as well
+	if ecs.IsInstance() || ecs.IsFargateInstance() {
 		l = append(l, config.Listeners{Name: "ecs"})
 	}
 	return l


### PR DESCRIPTION
This bumps datadog-agent dependency to the latest commit and incorporated one ecs update from @xvello .  @DataDog/burrito 