### PR TITLE
[proc] bump windows version to 6.4.1

### DIFF
--- a/gorake.rb
+++ b/gorake.rb
@@ -25,7 +25,7 @@ def go_build(program, opts={})
   agentversion = ENV["PROCESS_AGENT_VERSION"] || "0.99.0"
 
   # NOTE: This value is currently hardcoded and needs to be manually incremented during release
-  winversion = "6.4.0".split(".")
+  winversion = "6.4.1".split(".")
 
   vars = {}
   vars["#{dd}.Version"] = agentversion


### PR DESCRIPTION
Bumped windows version to 6.4.1 for process-agent. @DataDog/burrito 