### PR TITLE
Bumping tcptracer library for UDP connection support

### DIFF
--- a/checks/net.go
+++ b/checks/net.go
@@ -36,7 +36,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		return
 	}
 
-	t, err := tracer.NewTracer()
+	t, err := tracer.NewTracer(tracer.DefaultConfig)
 	if err != nil {
 		log.Errorf("failed to create network tracer: %s", err)
 		return
@@ -92,7 +92,7 @@ func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 		}
 	}
 
-	log.Infof("collected connections in %s", time.Since(start))
+	log.Debugf("collected connections in %s", time.Since(start))
 	return batchConnections(cfg, groupID, c.formatConnections(conns, lastConnByKey, c.prevCheckTime)), nil
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -184,7 +184,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/DataDog/tcptracer-bpf
-  version: 53ac204431e1bbeb7a08ef5c0177da0b1a46cd55
+  version: 1bb746d35b51a6c3a4aa21a27931257c0935beba
 - name: github.com/spf13/viper
   version: aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5
 - name: github.com/StackExchange/wmi


### PR DESCRIPTION
small PR to add UDP support from the tracer. Also includes some improvements around kprobe usage + map sizes (to track more connections!)

@DataDog/burrito 