### PR TITLE
polish

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -45,7 +45,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 5cad8f1a6bf6dca6a742fc0f85983c33f77f98ae
+  version: e6c3bef91cc04e1f0fc8546ef44e8ac0ccc98d2a
   subpackages:
   - cmd/agent/api/response
   - pkg/api/security

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/DataDog/datadog-process-agent
 import:
   - package: github.com/DataDog/datadog-agent
-    version: 5cad8f1a6bf6dca6a742fc0f85983c33f77f98ae
+    version: e6c3bef91cc04e1f0fc8546ef44e8ac0ccc98d2a
   - package: github.com/DataDog/agent-payload
   - package: github.com/docker/docker
     version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363

--- a/util/containers_linux.go
+++ b/util/containers_linux.go
@@ -40,7 +40,7 @@ func GetContainers() ([]*containers.Container, error) {
 		containers, ok := cached.([]*containers.Container)
 		if ok {
 			err := l.UpdateMetrics(containers)
-			log.Infof("Got %d containers from cache", len(containers))
+			log.Tracef("Got %d containers from cache", len(containers))
 			return containers, err
 		}
 		log.Errorf("Invalid container list cache format, forcing a cache miss")
@@ -52,7 +52,7 @@ func GetContainers() ([]*containers.Container, error) {
 		return nil, err
 	}
 	cache.Cache.Set(cacheKey, containers, containerCacheDuration)
-	log.Infof("Got %d containers from source %s", len(containers), name)
+	log.Tracef("Got %d containers from source %s", len(containers), name)
 	return containers, nil
 }
 


### PR DESCRIPTION
- Upgrade datadog-agent dependency, the placeholder `container_name` tag is now removed
- Downgrade container collection logs to `trace` level