### PR TITLE
Replace the main agent's logger instance with ours

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -6,9 +6,6 @@ import (
 	"flag"
 	_ "net/http/pprof"
 
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-process-agent/config"
 )
 
@@ -25,20 +22,6 @@ func main() {
 	// The default will be stdout since we can't assume any file is writeable.
 	if err := config.NewLoggerLevel("info", "", true); err != nil {
 		panic(err)
-	}
-
-	// Setup common logger
-	// FIXME: make it better
-	err := ddconfig.SetupLogger(
-		ddconfig.Datadog.GetString("log_level"),
-		"",
-		"",
-		false,
-		true,
-		false,
-	)
-	if err != nil {
-		log.Criticalf("Unable to setup logger: %s", err)
 	}
 
 	exit := make(chan bool)

--- a/config/log.go
+++ b/config/log.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
 	log "github.com/cihub/seelog"
 )
 
@@ -288,6 +289,12 @@ func replaceLogger(cfg *LoggerConfig) error {
 	if err != nil {
 		return err
 	}
+
+	// If the main agent has a logger, replace it with ours. If not, then set it up.
+	if ddlog.ReplaceLogger(logger) == nil {
+		ddlog.SetupDatadogLogger(logger, cfg.LogLevel)
+	}
+
 	return log.ReplaceLogger(logger)
 }
 


### PR DESCRIPTION
@DataDog/burrito 

Testing logs below:

**STDOUT** (until configuration is done and logger is changed)
```
$ ./process-agent
2018-08-29 16:42:56 INFO (tagger.go:79) - starting the tagging system
2018-08-29 16:42:56 INFO (tagger.go:151) - docker tag collector successfully started
2018-08-29 16:42:56 INFO (tagger.go:151) - ecs tag collector successfully started
2018-08-29 16:42:56 INFO (detector.go:123) - Collector docker successfully detected
2018-08-29 16:42:56 INFO (detector.go:83) - Using collector docker
2018-08-29 16:42:56 INFO (containers_linux.go:56) - Got 3 containers from source docker
2018-08-29 16:42:56 WARN (main.go:31) - found 3 api keys and 1 endpoints
```

**/var/log/datadog/process-agent.log**
```
2018-08-29 16:42:56 INFO (collector.go:99) - Starting process-agent for host=i-0bbe5b6786b866966, endpoints=[https://process.datad0g.com/api/v1/collector], enabled checks=[process rtprocess]
2018-08-29 16:42:56 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:42:56 INFO (collector.go:87) - Finished check #1 in 13.870774ms
2018-08-29 16:43:06 INFO (log.go:256) - Got 3 containers from source docker
2018-08-29 16:43:06 INFO (collector.go:87) - Finished check #2 in 27.298414ms
2018-08-29 16:43:07 INFO (collector.go:235) - Detected active clients, enabling real-time mode
2018-08-29 16:43:08 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:10 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:12 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:14 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:16 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:16 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:18 INFO (log.go:256) - Got 3 containers from source docker
2018-08-29 16:43:20 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:22 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:24 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:26 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:26 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:28 INFO (log.go:256) - Got 3 containers from cache
2018-08-29 16:43:30 INFO (log.go:256) - Got 3 containers from source docker
2018-08-29 16:43:31 CRITICAL (main_docker.go:28) - Caught signal 'interrupt'; terminating.
```
---
The reason `Got 3 containers from cache` is sourced from `log.go` is because logging in our `containers_linux.go` is using `"github.com/DataDog/datadog-agent/pkg/util/log"` atm.