### PR TITLE
Unused code + documentation

### DIFF
--- a/agent/main_common.go
+++ b/agent/main_common.go
@@ -147,14 +147,6 @@ func runAgent(exit chan bool) {
 		return
 	}
 
-	// Initialize the metadata providers so the singletons are available.
-	// This will log any unknown errors
-	initMetadataProviders()
-
-	if cfg.ContainerSource != "" {
-		util.SetContainerSource(cfg.ContainerSource)
-	}
-
 	// update docker socket path in info
 	dockerSock, err := util.GetDockerSocketPath()
 	if err != nil {

--- a/agent/main_docker.go
+++ b/agent/main_docker.go
@@ -7,15 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	log "github.com/cihub/seelog"
 )
-
-func initMetadataProviders() {
-	if _, err := docker.GetDockerUtil(); err != nil && err != docker.ErrDockerNotAvailable {
-		log.Errorf("unable to initialize docker collection: %s", err)
-	}
-}
 
 // Handles signals - tells us whether we should exit.
 func handleSignals(exit chan bool) {

--- a/agent/main_nodocker.go
+++ b/agent/main_nodocker.go
@@ -10,10 +10,6 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-func initMetadataProviders() {
-	// No-op
-}
-
 // Handles signals - tells us whether we should exit.
 func handleSignals(exit chan bool) {
 	sigIn := make(chan os.Signal, 100)

--- a/config/config.go
+++ b/config/config.go
@@ -484,9 +484,13 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 		durationS, _ := strconv.Atoi(v)
 		c.ContainerCacheDuration = time.Duration(durationS) * time.Second
 	}
+
+	// Used to override container source auto-detection.
+	// "docker", "ecs_fargate", "kubelet", etc
 	if v := os.Getenv("DD_PROCESS_AGENT_CONTAINER_SOURCE"); v != "" {
 		util.SetContainerSource(v)
 	}
+
 	// Note: this feature is in development and should not be used in production environments
 	if ok, _ := isAffirmative(os.Getenv("DD_CONNECTIONS_CHECK")); ok {
 		c.EnabledChecks = append(c.EnabledChecks, "connections")

--- a/config/config.go
+++ b/config/config.go
@@ -85,7 +85,6 @@ type AgentConfig struct {
 	ContainerWhitelist     []string
 	CollectDockerNetwork   bool
 	ContainerCacheDuration time.Duration
-	ContainerSource        string
 
 	// Internal store of a proxy used for generating the Transport
 	proxy proxyFunc
@@ -122,6 +121,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 		panic(err)
 	}
 
+	// Note: This only considers container sources that are already setup. It's possible that container sources may
+	//       need a few minutes to be ready.
 	_, err = util.GetContainers()
 	canAccessContainers := err == nil
 
@@ -170,7 +171,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 		// Docker
 		ContainerCacheDuration: 10 * time.Second,
 		CollectDockerNetwork:   true,
-		ContainerSource:        "",
 
 		// DataScrubber to hide command line sensitive words
 		Scrubber: NewDefaultDataScrubber(),
@@ -305,7 +305,7 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig) (*AgentConfig, e
 			cfg.MaxPerMessage = maxMessageBatch
 		}
 
-		// Checks intervals can be overriden by configuration.
+		// Checks intervals can be overridden by configuration.
 		for checkName, defaultInterval := range cfg.CheckIntervals {
 			key := fmt.Sprintf("%s_interval", checkName)
 			interval := agentIni.GetDurationDefault(ns, key, time.Second, defaultInterval)
@@ -485,7 +485,7 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 		c.ContainerCacheDuration = time.Duration(durationS) * time.Second
 	}
 	if v := os.Getenv("DD_PROCESS_AGENT_CONTAINER_SOURCE"); v != "" {
-		c.ContainerSource = v
+		util.SetContainerSource(v)
 	}
 	// Note: this feature is in development and should not be used in production environments
 	if ok, _ := isAffirmative(os.Getenv("DD_CONNECTIONS_CHECK")); ok {


### PR DESCRIPTION
Couple of small changes. Added some documentation via comments for `DD_PROCESS_AGENT_CONTAINER_SOURCE` and a possible issue with container auto-detection on initialization.

Also removed `initMetadataProviders`, which is no longer needed as `docker.GetDockerUtil()` is already called down the stack when we call `collectors.NewDetector("").