### PR TITLE
Updating pinned dependencies to fix agent build process

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 825d223bd5432a14c9710e1086380dea26ad97c91a0c0d4c8fef9dcdc0faf71a
-updated: 2018-09-04T14:45:00.702888741-04:00
+hash: d738dfeffba5bf154395c952711a2eed607d6279250619d97e1399c64622d4f7
+updated: 2018-09-04T15:18:54.755280466-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -221,7 +221,6 @@ imports:
   version: e61f72fec56ab519d74ebd396cd3fcf31b084558
   subpackages:
   - pkg/provider
-  - proto
 - name: github.com/magiconair/properties
   version: c2353362d570a7bfa228149c62842019201cfb71
 - name: github.com/mailru/easyjson
@@ -307,14 +306,11 @@ imports:
   - context
   - context/ctxhttp
   - http2
+  - http2/hpack
   - idna
   - lex/httplex
   - proxy
   - websocket
-- name: golang.org/x/net/http2
-  version: 8a410e7b638dca158bf9e766925842f6651ff828
-  subpackages:
-  - hpack
 - name: golang.org/x/sys
   version: 2b024373dcd9800f0cae693839fac6ede8d64a8c
   subpackages:
@@ -341,7 +337,9 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 - name: gopkg.in/zorkian/go-datadog-api.v2
-  version: d7b8b10db6a7eb1c1c2424b10a795a1662e80c9a
+  version: 6c08e2322af96e867e5715aedd6ea194c42cf44f
+  subpackages:
+  - proto
 - name: k8s.io/api
   version: 9e5ffd1f1320950b238cfce291b926411f0af722
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 28028e4a836e617df452f10e70e293f12b819a9c3144333567ad7e13328a681e
-updated: 2018-09-04T13:22:16.800336663-04:00
+hash: 825d223bd5432a14c9710e1086380dea26ad97c91a0c0d4c8fef9dcdc0faf71a
+updated: 2018-09-04T14:45:00.702888741-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/aws/aws-sdk-go
-  version: 2a4034064ca5271c3f875d43012285133154d664
+  version: 90dec2183a5f5458ee79cbaf4b8e9ab910bc81a6
   subpackages:
   - aws
   - aws/awserr
@@ -14,27 +14,19 @@ imports:
   - aws/corehandlers
   - aws/credentials
   - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/credentials/stscreds
-  - aws/csm
   - aws/defaults
   - aws/ec2metadata
-  - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
-  - internal/sdkio
-  - internal/sdkrand
-  - internal/sdkuri
-  - internal/shareddefaults
+  - private/endpoints
   - private/protocol
   - private/protocol/ec2query
-  - private/protocol/query
   - private/protocol/query/queryutil
   - private/protocol/rest
   - private/protocol/xml/xmlutil
+  - private/waiter
   - service/ec2
-  - service/sts
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
@@ -53,7 +45,7 @@ imports:
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
-  version: 9b3444c6fdcbe9a122a0bdacdd1476a78d326a97
+  version: dbdec93a04d629f18eeb491d30016da26652b69c
   subpackages:
   - cmd/agent/api/response
   - pkg/api/security
@@ -91,7 +83,7 @@ imports:
   - pkg/util/retry
   - pkg/version
 - name: github.com/DataDog/datadog-go
-  version: a9c7a9896c1847c9cc2b068a2ae68e9d74540a5d
+  version: 281ae9f2d8950e694e810c78daf74201d869b0d0
   subpackages:
   - statsd
 - name: github.com/DataDog/gopsutil
@@ -106,7 +98,8 @@ imports:
   - net
   - process
 - name: github.com/DataDog/tcptracer-bpf
-  version: 55269bd603ee1a3d9605c88c250df5ebd1d6b6f7
+  version: 61d5f2947657559a6ee966b2c288756e8c3e5adb
+  vcs: git
   subpackages:
   - pkg/tracer
 - name: github.com/DataDog/zstd
@@ -116,9 +109,9 @@ imports:
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: 90705d2fb81dda1466be49bd958ed8a0dd9a6145
+  version: 48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89
   subpackages:
-  - digestset
+  - digest
   - reference
 - name: github.com/docker/docker
   version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
@@ -157,6 +150,8 @@ imports:
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
   version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
+  subpackages:
+  - statsd
 - name: github.com/go-ole/go-ole
   version: 7a0fa49edf48165190530c675167e2f319a05268
   subpackages:
@@ -223,9 +218,10 @@ imports:
 - name: github.com/json-iterator/go
   version: f2b4162afba35581b6d4a50d3b8f34e33c144682
 - name: github.com/kubernetes-incubator/custom-metrics-apiserver
-  version: 1f1cda41a301080789507a291b999807002ede46
+  version: e61f72fec56ab519d74ebd396cd3fcf31b084558
   subpackages:
   - pkg/provider
+  - proto
 - name: github.com/magiconair/properties
   version: c2353362d570a7bfa228149c62842019201cfb71
 - name: github.com/mailru/easyjson
@@ -236,7 +232,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
 - name: github.com/Microsoft/go-winio
@@ -247,8 +243,6 @@ imports:
   version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
 - name: github.com/modern-go/reflect2
   version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
-- name: github.com/opencontainers/go-digest
-  version: c9281466c8b2f606084ac71339773efd177436e7
 - name: github.com/patrickmn/go-cache
   version: 5633e0862627c011927fa39556acae8b1f1df58a
 - name: github.com/pborman/uuid
@@ -301,8 +295,11 @@ imports:
 - name: github.com/StackExchange/wmi
   version: b12b22c5341f0c26d88c4d66176330500e84db68
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: c10c31b5e94b6f7a0283272dc2bb27163dcea24b
   subpackages:
+  - bcrypt
+  - blowfish
+  - ocsp
   - ssh/terminal
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
@@ -310,13 +307,16 @@ imports:
   - context
   - context/ctxhttp
   - http2
-  - http2/hpack
   - idna
   - lex/httplex
   - proxy
   - websocket
+- name: golang.org/x/net/http2
+  version: 8a410e7b638dca158bf9e766925842f6651ff828
+  subpackages:
+  - hpack
 - name: golang.org/x/sys
-  version: 95c6576299259db960f6c5b9b69ea52422860fce
+  version: 2b024373dcd9800f0cae693839fac6ede8d64a8c
   subpackages:
   - unix
   - windows
@@ -333,7 +333,7 @@ imports:
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/time
-  version: f51c12702a4d776e4c1fa9b0fabab841babae631
+  version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   subpackages:
   - rate
 - name: gopkg.in/inf.v0
@@ -343,7 +343,7 @@ imports:
 - name: gopkg.in/zorkian/go-datadog-api.v2
   version: d7b8b10db6a7eb1c1c2424b10a795a1662e80c9a
 - name: k8s.io/api
-  version: 73d903622b7391f3312dcbac6483fed484e185f8
+  version: 9e5ffd1f1320950b238cfce291b926411f0af722
   subpackages:
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
@@ -374,7 +374,7 @@ imports:
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 7022e8e5e6f8d55cdc303669184073a493482496
+  version: e386b2658ed20923da8cc9250e552f082899a1ee
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -408,7 +408,6 @@ imports:
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
-  - pkg/util/naming
   - pkg/util/net
   - pkg/util/rand
   - pkg/util/runtime
@@ -422,13 +421,12 @@ imports:
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: e9312c15296b6c2c923ebd5031ff5d1d5fd022d7
+  version: 2cf66d2375dce045e1e02e1d7b74a0d1e34fedb3
   subpackages:
   - pkg/admission
   - pkg/apis/apiserver
   - pkg/apis/apiserver/v1alpha1
   - pkg/apis/audit
-  - pkg/apis/audit/v1
   - pkg/apis/audit/v1alpha1
   - pkg/apis/audit/v1beta1
   - pkg/audit
@@ -445,6 +443,7 @@ imports:
   - pkg/storage/names
   - pkg/util/feature
   - pkg/util/flushwriter
+  - pkg/util/trace
   - pkg/util/wsstream
 - name: k8s.io/client-go
   version: 23781f4d6632d88e869066eaebb743857aa1ef9b
@@ -568,8 +567,10 @@ imports:
   - util/integer
   - util/retry
   - util/workqueue
+- name: k8s.io/kube-openapi
+  version: b742be413d0a6f781c123bed504c8fb39264c57d
 - name: k8s.io/metrics
-  version: 28511a0186e3bfac8cfa5c0c51b9e49d4c35a9d8
+  version: 0d9ea2ac660031c8f2726a735dda29441f396f99
   subpackages:
   - pkg/apis/custom_metrics
   - pkg/apis/external_metrics

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 97476456ed2475798ee9de52c55889f7d5da2ed1cc81dd4903b6cd01234a2c3a
-updated: 2018-07-31T11:29:01.489648785+02:00
+hash: da39f6de2eee3946398e1ab074b8f2289e63769021673f861b55d7d91caadeb8
+updated: 2018-09-04T13:01:25.863508351-04:00
 imports:
+- name: bitbucket.org/ww/goautoneg
+  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/aws/aws-sdk-go
-  version: bb029104295041aa34559192f1b08a2a318b7d4c
+  version: 2a4034064ca5271c3f875d43012285133154d664
   subpackages:
   - aws
   - aws/awserr
@@ -33,6 +35,12 @@ imports:
   - private/protocol/xml/xmlutil
   - service/ec2
   - service/sts
+- name: github.com/beorn7/perks
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  subpackages:
+  - quantile
+- name: github.com/cenkalti/backoff
+  version: b7325b0f3f1097c6546ea5e83c4a23267e58ad71
 - name: github.com/cihub/seelog
   version: f561c5e57575bb1e0a2167028b7339b3a8d16fb4
   subpackages:
@@ -41,7 +49,7 @@ imports:
   - archive/tar
   - archive/zip
 - name: github.com/DataDog/agent-payload
-  version: 3b793015ecfa5b829e8a466bd7cce836891502cc
+  version: f0521943f60221829c6bb5de1c7f788cd4411372
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-agent
@@ -51,6 +59,7 @@ imports:
   - pkg/api/security
   - pkg/api/util
   - pkg/autodiscovery/integration
+  - pkg/clusteragent/custommetrics
   - pkg/config
   - pkg/diagnose/diagnosis
   - pkg/errors
@@ -74,6 +83,9 @@ imports:
   - pkg/util/hostname
   - pkg/util/kubernetes
   - pkg/util/kubernetes/apiserver
+  - pkg/util/kubernetes/apiserver/common
+  - pkg/util/kubernetes/clustername
+  - pkg/util/kubernetes/hpa
   - pkg/util/kubernetes/kubelet
   - pkg/util/log
   - pkg/util/retry
@@ -94,13 +106,17 @@ imports:
   - net
   - process
 - name: github.com/DataDog/tcptracer-bpf
-  version: 8094abdab7ca742e291932493e1e4219944cbd4f
+  version: 55269bd603ee1a3d9605c88c250df5ebd1d6b6f7
   subpackages:
   - pkg/tracer
 - name: github.com/DataDog/zstd
   version: 2bf71ec4836011b92dc78df3b9ace6b40e65f7df
+- name: github.com/davecgh/go-spew
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
+  subpackages:
+  - spew
 - name: github.com/docker/distribution
-  version: 6664ec703991875e14419ff4960921cce7678bab
+  version: 90705d2fb81dda1466be49bd958ed8a0dd9a6145
   subpackages:
   - digestset
   - reference
@@ -124,21 +140,25 @@ imports:
   - client
   - pkg/tlsconfig
 - name: github.com/docker/go-connections
-  version: 7beb39f0b969b075d1325fecb092faf27fd357b6
+  version: 97c2040d34dfae1d1b1275fa3a78dbdd2f41cf7e
   subpackages:
   - nat
   - sockets
   - tlsconfig
 - name: github.com/docker/go-units
   version: 47565b4f722fb6ceae66b95f853feed578a4a51c
+- name: github.com/emicklei/go-restful
+  version: 68c9750c36bb8cb433f1b88c807b4b30df4acc40
+  subpackages:
+  - log
 - name: github.com/fsnotify/fsnotify
-  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
+  version: ccc981bf80385c528a65fbfdd49bf2d8da22aa23
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
   version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
 - name: github.com/go-ole/go-ole
-  version: a1ec82a652ebc7e784d7df887cfb31061aeabbcc
+  version: 7a0fa49edf48165190530c675167e2f319a05268
   subpackages:
   - oleutil
 - name: github.com/gogo/protobuf
@@ -152,13 +172,15 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
   - proto
   - ptypes
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
+- name: github.com/google/btree
+  version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/googleapis/gnostic
@@ -167,8 +189,16 @@ imports:
   - OpenAPIv2
   - compiler
   - extensions
+- name: github.com/gregjones/httpcache
+  version: 787624de3eb7bd915c329cba748687a3b22666a6
+  subpackages:
+  - diskcache
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
 - name: github.com/hashicorp/hcl
-  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
+  version: 8cb6e5b959231cc1119e43259c4a608f9c51a241
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -183,10 +213,8 @@ imports:
   version: 7f56832555fc229dad908c67d65ed3ce6156b70c
   subpackages:
   - api
-- name: github.com/howeyc/gopass
-  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
-  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+  version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
 - name: github.com/iovisor/gobpf
   version: 3b07770c6d5e2bd37e582ecd49460e6ef094f257
   repo: https://github.com/iovisor/gobpf
@@ -197,21 +225,62 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: github.com/json-iterator/go
-  version: 13f86432b882000a51c6e610c620974462691a97
+  version: f2b4162afba35581b6d4a50d3b8f34e33c144682
+- name: github.com/kubernetes-incubator/custom-metrics-apiserver
+  version: 1f1cda41a301080789507a291b999807002ede46
+  subpackages:
+  - pkg/provider
 - name: github.com/magiconair/properties
-  version: c3beff4c2358b44d0493c7dda585e7db7ff28ae6
+  version: c2353362d570a7bfa228149c62842019201cfb71
+- name: github.com/mailru/easyjson
+  version: 60711f1a8329503b04e1c88535f419d0bb440bff
+  repo: https://github.com/mailru/easyjson
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/Microsoft/go-winio
-  version: 7da180ee92d8bd8bb8c37fc560e673e6557c392f
+  version: 97e4973ce50b2ff5f09635a57e2b88a037aae829
 - name: github.com/mitchellh/mapstructure
-  version: a4e142e9c047c904fa2f1e144d9a84e6133024bc
+  version: fa473d140ef3c6adf42d6b391fe76707f1f243c8
+- name: github.com/modern-go/concurrent
+  version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
+- name: github.com/modern-go/reflect2
+  version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
 - name: github.com/opencontainers/go-digest
-  version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
+  version: c9281466c8b2f606084ac71339773efd177436e7
 - name: github.com/patrickmn/go-cache
-  version: a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0
+  version: 5633e0862627c011927fa39556acae8b1f1df58a
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pelletier/go-toml
-  version: acdc4509485b587f5e675510c4f2c63e90ff68a8
+  version: c2dbbc24a97911339e01bda0b8cabdbd8f13b602
+- name: github.com/peterbourgon/diskv
+  version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/pkg/errors
-  version: 30136e27e2ac8d167177e8a583aa4c3fea5be833
+  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
+- name: github.com/prometheus/client_golang
+  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
+  subpackages:
+  - prometheus
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
+  subpackages:
+  - xfs
 - name: github.com/shirou/gopsutil
   version: e30b7839cd6161b2fbef5f187377a345157abe04
   subpackages:
@@ -224,21 +293,21 @@ imports:
 - name: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/spf13/afero
-  version: bbf41cb36dffe15dff5bf7e18c447801e7ffe163
+  version: 787d034dfe70e44075ccc060d346146ef53270ad
   subpackages:
   - mem
 - name: github.com/spf13/cast
   version: 8965335b8c7107321228e3e3702cab9832751bac
 - name: github.com/spf13/jwalterweatherman
-  version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
+  version: 14d3d4c518341bea657dd8a226f5121c0ff8c9f2
 - name: github.com/spf13/pflag
-  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/spf13/viper
-  version: aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5
+  version: 0ac2068de99fd349edc4954d0e9b4a600d75da44
 - name: github.com/StackExchange/wmi
-  version: 5d049714c4a64225c3c79a7cf7d02f7fb5b96338
+  version: b12b22c5341f0c26d88c4d66176330500e84db68
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -251,6 +320,14 @@ imports:
   - idna
   - lex/httplex
   - proxy
+  - websocket
+- name: golang.org/x/oauth2
+  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
   version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
@@ -272,12 +349,24 @@ imports:
   version: f51c12702a4d776e4c1fa9b0fabab841babae631
   subpackages:
   - rate
+- name: google.golang.org/appengine
+  version: 03cac3b07182cfb08c0d0c0b6ee72a1ceb151c92
+  subpackages:
+  - internal
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
-  version: 670d4cfef0544295bc27a114dbac37980d83185a
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+- name: gopkg.in/zorkian/go-datadog-api.v2
+  version: d7b8b10db6a7eb1c1c2424b10a795a1662e80c9a
 - name: k8s.io/api
-  version: 0d0b2f481328d8bae556061a08a02175054059f4
+  version: fcb01e9febf3e72ae9b6eff41f2d02ffdea4dda1
   subpackages:
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
@@ -290,10 +379,12 @@ imports:
   - authorization/v1beta1
   - autoscaling/v1
   - autoscaling/v2beta1
+  - autoscaling/v2beta2
   - batch/v1
   - batch/v1beta1
   - batch/v2alpha1
   - certificates/v1beta1
+  - coordination/v1beta1
   - core/v1
   - events/v1beta1
   - extensions/v1beta1
@@ -303,18 +394,24 @@ imports:
   - rbac/v1alpha1
   - rbac/v1beta1
   - scheduling/v1alpha1
+  - scheduling/v1beta1
   - settings/v1alpha1
   - storage/v1
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: da3b134bab57ebf23dedfec7e0004614dd4b5a24
+  version: 7022e8e5e6f8d55cdc303669184073a493482496
   subpackages:
+  - pkg/api/equality
   - pkg/api/errors
   - pkg/api/meta
   - pkg/api/resource
+  - pkg/api/validation
+  - pkg/api/validation/path
+  - pkg/apis/meta/internalversion
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1/validation
   - pkg/apis/meta/v1beta1
   - pkg/conversion
   - pkg/conversion/queryparams
@@ -330,14 +427,19 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
+  - pkg/util/cache
   - pkg/util/clock
+  - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/naming
   - pkg/util/net
+  - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
@@ -345,10 +447,80 @@ imports:
   - pkg/version
   - pkg/watch
   - third_party/forked/golang/reflect
+- name: k8s.io/apiserver
+  version: e9312c15296b6c2c923ebd5031ff5d1d5fd022d7
+  subpackages:
+  - pkg/admission
+  - pkg/apis/apiserver
+  - pkg/apis/apiserver/v1alpha1
+  - pkg/apis/audit
+  - pkg/apis/audit/v1
+  - pkg/apis/audit/v1alpha1
+  - pkg/apis/audit/v1beta1
+  - pkg/audit
+  - pkg/authentication/user
+  - pkg/authorization/authorizer
+  - pkg/endpoints/discovery
+  - pkg/endpoints/handlers/negotiation
+  - pkg/endpoints/handlers/responsewriters
+  - pkg/endpoints/metrics
+  - pkg/endpoints/request
+  - pkg/features
+  - pkg/registry/rest
+  - pkg/storage
+  - pkg/storage/names
+  - pkg/util/feature
+  - pkg/util/flushwriter
+  - pkg/util/wsstream
 - name: k8s.io/client-go
-  version: 3bf59c62ad4eec87ccad4dbb46f569c134f71448
+  version: f06dbfd7354359a944eca1b0a555067933f10c3e
   subpackages:
   - discovery
+  - dynamic
+  - informers
+  - informers/admissionregistration
+  - informers/admissionregistration/v1alpha1
+  - informers/admissionregistration/v1beta1
+  - informers/apps
+  - informers/apps/v1
+  - informers/apps/v1beta1
+  - informers/apps/v1beta2
+  - informers/autoscaling
+  - informers/autoscaling/v1
+  - informers/autoscaling/v2beta1
+  - informers/autoscaling/v2beta2
+  - informers/batch
+  - informers/batch/v1
+  - informers/batch/v1beta1
+  - informers/batch/v2alpha1
+  - informers/certificates
+  - informers/certificates/v1beta1
+  - informers/coordination
+  - informers/coordination/v1beta1
+  - informers/core
+  - informers/core/v1
+  - informers/events
+  - informers/events/v1beta1
+  - informers/extensions
+  - informers/extensions/v1beta1
+  - informers/internalinterfaces
+  - informers/networking
+  - informers/networking/v1
+  - informers/policy
+  - informers/policy/v1beta1
+  - informers/rbac
+  - informers/rbac/v1
+  - informers/rbac/v1alpha1
+  - informers/rbac/v1beta1
+  - informers/scheduling
+  - informers/scheduling/v1alpha1
+  - informers/scheduling/v1beta1
+  - informers/settings
+  - informers/settings/v1alpha1
+  - informers/storage
+  - informers/storage/v1
+  - informers/storage/v1alpha1
+  - informers/storage/v1beta1
   - kubernetes
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
@@ -362,10 +534,12 @@ imports:
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/autoscaling/v1
   - kubernetes/typed/autoscaling/v2beta1
+  - kubernetes/typed/autoscaling/v2beta2
   - kubernetes/typed/batch/v1
   - kubernetes/typed/batch/v1beta1
   - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/coordination/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/events/v1beta1
   - kubernetes/typed/extensions/v1beta1
@@ -375,35 +549,74 @@ imports:
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
   - kubernetes/typed/scheduling/v1alpha1
+  - kubernetes/typed/scheduling/v1beta1
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1alpha1
   - kubernetes/typed/storage/v1beta1
+  - listers/admissionregistration/v1alpha1
+  - listers/admissionregistration/v1beta1
+  - listers/apps/v1
+  - listers/apps/v1beta1
+  - listers/apps/v1beta2
+  - listers/autoscaling/v1
+  - listers/autoscaling/v2beta1
+  - listers/autoscaling/v2beta2
+  - listers/batch/v1
+  - listers/batch/v1beta1
+  - listers/batch/v2alpha1
+  - listers/certificates/v1beta1
+  - listers/coordination/v1beta1
+  - listers/core/v1
+  - listers/events/v1beta1
+  - listers/extensions/v1beta1
+  - listers/networking/v1
+  - listers/policy/v1beta1
+  - listers/rbac/v1
+  - listers/rbac/v1alpha1
+  - listers/rbac/v1beta1
+  - listers/scheduling/v1alpha1
+  - listers/scheduling/v1beta1
+  - listers/settings/v1alpha1
+  - listers/storage/v1
+  - listers/storage/v1alpha1
+  - listers/storage/v1beta1
+  - pkg/apis/clientauthentication
+  - pkg/apis/clientauthentication/v1alpha1
+  - pkg/apis/clientauthentication/v1beta1
   - pkg/version
+  - plugin/pkg/client/auth/exec
   - rest
   - rest/watch
   - tools/auth
+  - tools/cache
   - tools/clientcmd
   - tools/clientcmd/api
   - tools/clientcmd/api/latest
   - tools/clientcmd/api/v1
   - tools/metrics
+  - tools/pager
   - tools/reference
   - transport
+  - util/buffer
   - util/cert
+  - util/connrotation
   - util/flowcontrol
   - util/homedir
   - util/integer
-testImports:
-- name: github.com/davecgh/go-spew
-  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
+  - util/retry
+  - util/workqueue
+- name: k8s.io/metrics
+  version: 28511a0186e3bfac8cfa5c0c51b9e49d4c35a9d8
   subpackages:
-  - spew
+  - pkg/apis/custom_metrics
+  - pkg/apis/external_metrics
+testImports:
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: be8372ae8ec5c6daaed3cc28ebf73c54b737c240
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: da39f6de2eee3946398e1ab074b8f2289e63769021673f861b55d7d91caadeb8
-updated: 2018-09-04T13:01:25.863508351-04:00
+hash: 28028e4a836e617df452f10e70e293f12b819a9c3144333567ad7e13328a681e
+updated: 2018-09-04T13:22:16.800336663-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -179,8 +179,6 @@ imports:
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
-- name: github.com/google/btree
-  version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/googleapis/gnostic
@@ -189,10 +187,6 @@ imports:
   - OpenAPIv2
   - compiler
   - extensions
-- name: github.com/gregjones/httpcache
-  version: 787624de3eb7bd915c329cba748687a3b22666a6
-  subpackages:
-  - diskcache
 - name: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
@@ -213,8 +207,10 @@ imports:
   version: 7f56832555fc229dad908c67d65ed3ce6156b70c
   subpackages:
   - api
+- name: github.com/howeyc/gopass
+  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
-  version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
+  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/iovisor/gobpf
   version: 3b07770c6d5e2bd37e582ecd49460e6ef094f257
   repo: https://github.com/iovisor/gobpf
@@ -259,8 +255,6 @@ imports:
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pelletier/go-toml
   version: c2dbbc24a97911339e01bda0b8cabdbd8f13b602
-- name: github.com/peterbourgon/diskv
-  version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/pkg/errors
   version: 816c9085562cd7ee03e7f8188a1cfd942858cded
 - name: github.com/prometheus/client_golang
@@ -307,7 +301,7 @@ imports:
 - name: github.com/StackExchange/wmi
   version: b12b22c5341f0c26d88c4d66176330500e84db68
 - name: golang.org/x/crypto
-  version: de0752318171da717af4ce24d0a2e8626afaeb11
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -321,13 +315,6 @@ imports:
   - lex/httplex
   - proxy
   - websocket
-- name: golang.org/x/oauth2
-  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
-  subpackages:
-  - google
-  - internal
-  - jws
-  - jwt
 - name: golang.org/x/sys
   version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
@@ -349,16 +336,6 @@ imports:
   version: f51c12702a4d776e4c1fa9b0fabab841babae631
   subpackages:
   - rate
-- name: google.golang.org/appengine
-  version: 03cac3b07182cfb08c0d0c0b6ee72a1ceb151c92
-  subpackages:
-  - internal
-  - internal/base
-  - internal/datastore
-  - internal/log
-  - internal/remote_api
-  - internal/urlfetch
-  - urlfetch
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
@@ -366,7 +343,7 @@ imports:
 - name: gopkg.in/zorkian/go-datadog-api.v2
   version: d7b8b10db6a7eb1c1c2424b10a795a1662e80c9a
 - name: k8s.io/api
-  version: fcb01e9febf3e72ae9b6eff41f2d02ffdea4dda1
+  version: 73d903622b7391f3312dcbac6483fed484e185f8
   subpackages:
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
@@ -379,12 +356,10 @@ imports:
   - authorization/v1beta1
   - autoscaling/v1
   - autoscaling/v2beta1
-  - autoscaling/v2beta2
   - batch/v1
   - batch/v1beta1
   - batch/v2alpha1
   - certificates/v1beta1
-  - coordination/v1beta1
   - core/v1
   - events/v1beta1
   - extensions/v1beta1
@@ -394,7 +369,6 @@ imports:
   - rbac/v1alpha1
   - rbac/v1beta1
   - scheduling/v1alpha1
-  - scheduling/v1beta1
   - settings/v1alpha1
   - storage/v1
   - storage/v1alpha1
@@ -473,7 +447,7 @@ imports:
   - pkg/util/flushwriter
   - pkg/util/wsstream
 - name: k8s.io/client-go
-  version: f06dbfd7354359a944eca1b0a555067933f10c3e
+  version: 23781f4d6632d88e869066eaebb743857aa1ef9b
   subpackages:
   - discovery
   - dynamic
@@ -488,15 +462,12 @@ imports:
   - informers/autoscaling
   - informers/autoscaling/v1
   - informers/autoscaling/v2beta1
-  - informers/autoscaling/v2beta2
   - informers/batch
   - informers/batch/v1
   - informers/batch/v1beta1
   - informers/batch/v2alpha1
   - informers/certificates
   - informers/certificates/v1beta1
-  - informers/coordination
-  - informers/coordination/v1beta1
   - informers/core
   - informers/core/v1
   - informers/events
@@ -514,7 +485,6 @@ imports:
   - informers/rbac/v1beta1
   - informers/scheduling
   - informers/scheduling/v1alpha1
-  - informers/scheduling/v1beta1
   - informers/settings
   - informers/settings/v1alpha1
   - informers/storage
@@ -534,12 +504,10 @@ imports:
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/autoscaling/v1
   - kubernetes/typed/autoscaling/v2beta1
-  - kubernetes/typed/autoscaling/v2beta2
   - kubernetes/typed/batch/v1
   - kubernetes/typed/batch/v1beta1
   - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/certificates/v1beta1
-  - kubernetes/typed/coordination/v1beta1
   - kubernetes/typed/core/v1
   - kubernetes/typed/events/v1beta1
   - kubernetes/typed/extensions/v1beta1
@@ -549,7 +517,6 @@ imports:
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
   - kubernetes/typed/scheduling/v1alpha1
-  - kubernetes/typed/scheduling/v1beta1
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1alpha1
@@ -561,12 +528,10 @@ imports:
   - listers/apps/v1beta2
   - listers/autoscaling/v1
   - listers/autoscaling/v2beta1
-  - listers/autoscaling/v2beta2
   - listers/batch/v1
   - listers/batch/v1beta1
   - listers/batch/v2alpha1
   - listers/certificates/v1beta1
-  - listers/coordination/v1beta1
   - listers/core/v1
   - listers/events/v1beta1
   - listers/extensions/v1beta1
@@ -576,14 +541,12 @@ imports:
   - listers/rbac/v1alpha1
   - listers/rbac/v1beta1
   - listers/scheduling/v1alpha1
-  - listers/scheduling/v1beta1
   - listers/settings/v1alpha1
   - listers/storage/v1
   - listers/storage/v1alpha1
   - listers/storage/v1beta1
   - pkg/apis/clientauthentication
   - pkg/apis/clientauthentication/v1alpha1
-  - pkg/apis/clientauthentication/v1beta1
   - pkg/version
   - plugin/pkg/client/auth/exec
   - rest
@@ -600,7 +563,6 @@ imports:
   - transport
   - util/buffer
   - util/cert
-  - util/connrotation
   - util/flowcontrol
   - util/homedir
   - util/integer

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,6 +36,8 @@ import:
     version: d76fbc1373015ced59b43ac267f28d546b955683
   - package: github.com/kubernetes-incubator/custom-metrics-apiserver
     version: e61f72fec56ab519d74ebd396cd3fcf31b084558
+  - package: gopkg.in/zorkian/go-datadog-api.v2
+    version: 6c08e2322af96e867e5715aedd6ea194c42cf44f
     subpackages:
     - proto
   - package: github.com/go-ini/ini

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,18 +1,31 @@
 package: github.com/DataDog/datadog-process-agent
 import:
   - package: github.com/DataDog/datadog-agent
-    version: 9b3444c6fdcbe9a122a0bdacdd1476a78d326a97
-  - package: k8s.io/client-go
-    version: 23781f4d6632d88e869066eaebb743857aa1ef9b
-  - package: github.com/DataDog/agent-payload
-  - package: github.com/docker/docker
-    version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
+    version: dbdec93a04d629f18eeb491d30016da26652b69c
   - package: github.com/DataDog/tcptracer-bpf
+    vcs: git
+    version: dd
   - package: github.com/DataDog/gopsutil
     vcs: git
     version: dd
     subpackages:
     - gogen
+  - package: github.com/docker/docker
+    version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
+  - package: github.com/docker/distribution
+    version: 48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89
+  - package: k8s.io/api
+    version: 9e5ffd1f1320950b238cfce291b926411f0af722
+  - package: k8s.io/apimachinery
+    version: e386b2658ed20923da8cc9250e552f082899a1ee
+  - package: k8s.io/apiserver
+    version: 2cf66d2375dce045e1e02e1d7b74a0d1e34fedb3
+  - package: k8s.io/client-go
+    version: 23781f4d6632d88e869066eaebb743857aa1ef9b
+  - package: k8s.io/kube-openapi
+    version: b742be413d0a6f781c123bed504c8fb39264c57d
+  - package: k8s.io/metrics
+    version: 0d9ea2ac660031c8f2726a735dda29441f396f99
   - package: github.com/shirou/gopsutil
     version: e30b7839cd6161b2fbef5f187377a345157abe04
   - package: github.com/DataDog/zstd
@@ -21,12 +34,12 @@ import:
     version: f561c5e57575bb1e0a2167028b7339b3a8d16fb4
   - package: github.com/gogo/protobuf
     version: d76fbc1373015ced59b43ac267f28d546b955683
+  - package: github.com/kubernetes-incubator/custom-metrics-apiserver
+    version: e61f72fec56ab519d74ebd396cd3fcf31b084558
     subpackages:
     - proto
   - package: github.com/go-ini/ini
     version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
-  - package: github.com/DataDog/datadog-go
-    version: a9c7a9896c1847c9cc2b068a2ae68e9d74540a5d
     subpackages:
     - statsd
 testImport:

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,8 @@ package: github.com/DataDog/datadog-process-agent
 import:
   - package: github.com/DataDog/datadog-agent
     version: 9b3444c6fdcbe9a122a0bdacdd1476a78d326a97
+  - package: k8s.io/client-go
+    version: 23781f4d6632d88e869066eaebb743857aa1ef9b
   - package: github.com/DataDog/agent-payload
   - package: github.com/docker/docker
     version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363


### PR DESCRIPTION
[see: title]

- Pin to the same versions, as the main agent, for `k8s.io/...`
- Pin to an older version of gopkg.in/zorkian/go-datadog-api.v2, due to a known bug [(changed data structure)](https://github.com/zorkian/go-datadog-api/commit/6c08e2322af96e867e5715aedd6ea194c42cf44f)
  - Fix for `datadog-agent` in progress

@DataDog/burrito 
