### PR TITLE
[container] protect against nil stats on containers from ecs fargate

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -21,9 +21,9 @@ var Container = &ContainerCheck{}
 
 // ContainerCheck is a check that returns container metadata and stats.
 type ContainerCheck struct {
-	sysInfo   *model.SystemInfo
-	lastRates map[string]util.ContainerRateMetrics
-	lastRun   time.Time
+	sysInfo        *model.SystemInfo
+	lastContainers []*containers.Container
+	lastRun        time.Time
 }
 
 // Init initializes a ContainerCheck instance.
@@ -50,8 +50,8 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	}
 
 	// End check early if this is our first run.
-	if c.lastRates == nil {
-		c.lastRates = util.ExtractContainerRateMetric(ctrList)
+	if c.lastContainers == nil {
+		c.lastContainers = ctrList
 		c.lastRun = time.Now()
 		return nil, nil
 	}
@@ -60,7 +60,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if len(ctrList) != cfg.MaxPerMessage {
 		groupSize++
 	}
-	chunked := fmtContainers(ctrList, c.lastRates, c.lastRun, groupSize)
+	chunked := fmtContainers(ctrList, c.lastContainers, c.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	totalContainers := float64(0)
 	for i := 0; i < groupSize; i++ {
@@ -74,7 +74,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 		})
 	}
 
-	c.lastRates = util.ExtractContainerRateMetric(ctrList)
+	c.lastContainers = ctrList
 	c.lastRun = time.Now()
 
 	statsd.Client.Gauge("datadog.process.containers.host_count", totalContainers, []string{}, 1)
@@ -85,35 +85,33 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 // fmtContainers formats and chunks the ctrList into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
 func fmtContainers(
-	ctrList []*containers.Container,
-	lastRates map[string]util.ContainerRateMetrics,
+	ctrList, lastContainers []*containers.Container,
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.Container {
+	lastByID := make(map[string]*containers.Container, len(ctrList))
+	for _, c := range lastContainers {
+		lastByID[c.ID] = c
+	}
+
 	perChunk := (len(ctrList) / chunks) + 1
 	chunked := make([][]*model.Container, chunks)
 	chunk := make([]*model.Container, 0, perChunk)
 	i := 0
 	for _, ctr := range ctrList {
-		lastCtr, ok := lastRates[ctr.ID]
+		lastCtr, ok := lastByID[ctr.ID]
 		if !ok {
 			// Set to an empty container so rate calculations work and use defaults.
-			lastCtr = util.NullContainerRates
+			lastCtr = util.NullContainer
 		}
 
 		// Just in case the container is found, but refs are nil
-		if lastCtr.CPU == nil {
-			lastCtr.CPU = util.NullContainerRates.CPU
-		}
-		if lastCtr.IO == nil {
-			lastCtr.IO = util.NullContainerRates.IO
-		}
-		if lastCtr.NetworkSum == nil {
-			lastCtr.NetworkSum = util.NullContainerRates.NetworkSum
-		}
+		fillNilContainers(ctr, lastCtr)
 
 		ifStats := ctr.Network.SumInterfaces()
+		lastIfStats := lastCtr.Network.SumInterfaces()
 		cpus := runtime.NumCPU()
+		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
 		// Retrieves metadata tags
 		tags, err := tagger.Tag(ctr.EntityID, true)
@@ -122,42 +120,28 @@ func fmtContainers(
 			tags = []string{}
 		}
 
-		cntModel := &model.Container{
+		chunk = append(chunk, &model.Container{
 			Id:          ctr.ID,
 			Type:        ctr.Type,
 			CpuLimit:    float32(ctr.CPULimit),
+			UserPct:     calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, lastRun),
+			SystemPct:   calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, lastRun),
+			TotalPct:    calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, lastRun),
 			MemoryLimit: ctr.MemLimit,
+			MemRss:      ctr.Memory.RSS,
+			MemCache:    ctr.Memory.Cache,
 			Created:     ctr.Created,
 			State:       model.ContainerState(model.ContainerState_value[ctr.State]),
 			Health:      model.ContainerHealth(model.ContainerHealth_value[ctr.Health]),
-			NetRcvdPs:   calculateRate(ifStats.PacketsRcvd, lastCtr.NetworkSum.PacketsRcvd, lastRun),
-			NetSentPs:   calculateRate(ifStats.PacketsSent, lastCtr.NetworkSum.PacketsSent, lastRun),
-			NetRcvdBps:  calculateRate(ifStats.BytesRcvd, lastCtr.NetworkSum.BytesRcvd, lastRun),
-			NetSentBps:  calculateRate(ifStats.BytesSent, lastCtr.NetworkSum.BytesSent, lastRun),
+			Rbps:        calculateRate(ctr.IO.ReadBytes, lastCtr.IO.ReadBytes, lastRun),
+			Wbps:        calculateRate(ctr.IO.WriteBytes, lastCtr.IO.WriteBytes, lastRun),
+			NetRcvdPs:   calculateRate(ifStats.PacketsRcvd, lastIfStats.PacketsRcvd, lastRun),
+			NetSentPs:   calculateRate(ifStats.PacketsSent, lastIfStats.PacketsSent, lastRun),
+			NetRcvdBps:  calculateRate(ifStats.BytesRcvd, lastIfStats.BytesRcvd, lastRun),
+			NetSentBps:  calculateRate(ifStats.BytesSent, lastIfStats.BytesSent, lastRun),
 			Started:     ctr.StartedAt,
 			Tags:        tags,
-		}
-
-		// we know lastCtr is good to calculate because we use NullContainerRates if nil
-		if ctr.CPU != nil {
-			sysUsage2, sysUsage1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
-			usr2, usr1 := ctr.CPU.User, lastCtr.CPU.User
-			sys2, sys1 := ctr.CPU.System, lastCtr.CPU.System
-
-			cntModel.UserPct = calculateCtrPct(usr2, usr1, sysUsage2, sysUsage1, cpus, lastRun)
-			cntModel.SystemPct = calculateCtrPct(sys2, sys1, sysUsage2, sysUsage1, cpus, lastRun)
-			cntModel.TotalPct = calculateCtrPct(usr2+sys2, usr1+sys1, sys2, sys1, cpus, lastRun)
-		}
-		if ctr.Memory != nil {
-			cntModel.MemRss = ctr.Memory.RSS
-			cntModel.MemCache = ctr.Memory.Cache
-		}
-		if ctr.IO != nil {
-			cntModel.Rbps = calculateRate(ctr.IO.ReadBytes, lastCtr.IO.ReadBytes, lastRun)
-			cntModel.Wbps = calculateRate(ctr.IO.WriteBytes, lastCtr.IO.WriteBytes, lastRun)
-		}
-
-		chunk = append(chunk, cntModel)
+		})
 
 		if len(chunk) == perChunk {
 			chunked[i] = chunk
@@ -186,4 +170,21 @@ func calculateCtrPct(cur, prev, sys2, sys1 uint64, numCPU int, before time.Time)
 		return (cpuDelta / sysDelta) * float32(numCPU) * 100
 	}
 	return float32(cur-prev) / float32(diff)
+}
+
+func fillNilContainers(ctrs ...*containers.Container) {
+	for _, c := range ctrs {
+		if c.CPU == nil {
+			c.CPU = util.NullContainer.CPU
+		}
+		if c.Memory == nil {
+			c.Memory = util.NullContainer.Memory
+		}
+		if c.IO == nil {
+			c.IO = util.NullContainer.IO
+		}
+		if c.Network == nil {
+			c.Network = util.NullContainer.Network
+		}
+	}
 }

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -18,9 +18,9 @@ var RTContainer = &RTContainerCheck{}
 
 // RTContainerCheck collects numeric statistics about live ctrList.
 type RTContainerCheck struct {
-	sysInfo   *model.SystemInfo
-	lastRates map[string]util.ContainerRateMetrics
-	lastRun   time.Time
+	sysInfo        *model.SystemInfo
+	lastContainers []*containers.Container
+	lastRun        time.Time
 }
 
 // Init initializes a RTContainerCheck instance.
@@ -45,8 +45,8 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	}
 
 	// End check early if this is our first run.
-	if r.lastRates == nil {
-		r.lastRates = util.ExtractContainerRateMetric(ctrList)
+	if r.lastContainers == nil {
+		r.lastContainers = ctrList
 		r.lastRun = time.Now()
 		return nil, nil
 	}
@@ -55,7 +55,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	if len(ctrList) != cfg.MaxPerMessage {
 		groupSize++
 	}
-	chunked := fmtContainerStats(ctrList, r.lastRates, r.lastRun, groupSize)
+	chunked := fmtContainerStats(ctrList, r.lastContainers, r.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	for i := 0; i < groupSize; i++ {
 		messages = append(messages, &model.CollectorContainerRealTime{
@@ -68,7 +68,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 		})
 	}
 
-	r.lastRates = util.ExtractContainerRateMetric(ctrList)
+	r.lastContainers = ctrList
 	r.lastRun = time.Now()
 
 	return messages, nil
@@ -77,23 +77,31 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 // fmtContainerStats formats and chunks the ctrList into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
 func fmtContainerStats(
-	ctrList []*containers.Container,
-	lastRates map[string]util.ContainerRateMetrics,
+	ctrList, lastContainers []*containers.Container,
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.ContainerStat {
+	lastByID := make(map[string]*containers.Container, len(ctrList))
+	for _, c := range lastContainers {
+		lastByID[c.ID] = c
+	}
+
 	perChunk := (len(ctrList) / chunks) + 1
 	chunked := make([][]*model.ContainerStat, chunks)
 	chunk := make([]*model.ContainerStat, 0, perChunk)
 	i := 0
 	for _, ctr := range ctrList {
-		lastCtr, ok := lastRates[ctr.ID]
+		lastCtr, ok := lastByID[ctr.ID]
 		if !ok {
 			// Set to an empty container so rate calculations work and use defaults.
-			lastCtr = util.NullContainerRates
+			lastCtr = util.NullContainer
 		}
 
+		// Just in case the container is found, but refs are nil
+		fillNilContainers(ctr, lastCtr)
+
 		ifStats := ctr.Network.SumInterfaces()
+		lastIfStats := lastCtr.Network.SumInterfaces()
 		cpus := runtime.NumCPU()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 		chunk = append(chunk, &model.ContainerStat{
@@ -107,10 +115,10 @@ func fmtContainerStats(
 			MemLimit:   ctr.MemLimit,
 			Rbps:       calculateRate(ctr.IO.ReadBytes, lastCtr.IO.ReadBytes, lastRun),
 			Wbps:       calculateRate(ctr.IO.WriteBytes, lastCtr.IO.WriteBytes, lastRun),
-			NetRcvdPs:  calculateRate(ifStats.PacketsRcvd, lastCtr.NetworkSum.PacketsRcvd, lastRun),
-			NetSentPs:  calculateRate(ifStats.PacketsSent, lastCtr.NetworkSum.PacketsSent, lastRun),
-			NetRcvdBps: calculateRate(ifStats.BytesRcvd, lastCtr.NetworkSum.BytesRcvd, lastRun),
-			NetSentBps: calculateRate(ifStats.BytesSent, lastCtr.NetworkSum.BytesSent, lastRun),
+			NetRcvdPs:  calculateRate(ifStats.PacketsRcvd, lastIfStats.PacketsRcvd, lastRun),
+			NetSentPs:  calculateRate(ifStats.PacketsSent, lastIfStats.PacketsSent, lastRun),
+			NetRcvdBps: calculateRate(ifStats.BytesRcvd, lastIfStats.BytesRcvd, lastRun),
+			NetSentBps: calculateRate(ifStats.BytesSent, lastIfStats.BytesSent, lastRun),
 			State:      model.ContainerState(model.ContainerState_value[ctr.State]),
 			Health:     model.ContainerHealth(model.ContainerHealth_value[ctr.Health]),
 			Started:    ctr.StartedAt,

--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-process-agent/util"
 )
 
 func makeContainer(id string) *containers.Container {
@@ -29,26 +27,25 @@ func TestContainerChunking(t *testing.T) {
 	lastRun := time.Now().Add(-5 * time.Second)
 
 	for i, tc := range []struct {
-		cur      []*containers.Container
-		last     map[string]util.ContainerRateMetrics
-		chunks   int
-		expected int
+		cur, last []*containers.Container
+		chunks    int
+		expected  int
 	}{
 		{
 			cur:      []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
-			last:     util.ExtractContainerRateMetric([]*containers.Container{ctrs[0], ctrs[1], ctrs[2]}),
+			last:     []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
 			chunks:   2,
 			expected: 3,
 		},
 		{
 			cur:      []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
-			last:     util.ExtractContainerRateMetric([]*containers.Container{ctrs[0], ctrs[2]}),
+			last:     []*containers.Container{ctrs[0], ctrs[2]},
 			chunks:   2,
 			expected: 3,
 		},
 		{
 			cur:      []*containers.Container{ctrs[0], ctrs[2]},
-			last:     util.ExtractContainerRateMetric([]*containers.Container{ctrs[0], ctrs[1], ctrs[2]}),
+			last:     []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
 			chunks:   20,
 			expected: 2,
 		},
@@ -70,4 +67,29 @@ func TestContainerChunking(t *testing.T) {
 		assert.Equal(t, tc.expected, total, "total test %d", i)
 
 	}
+}
+
+func TestContainerNils(t *testing.T) {
+	// Make sure formatting doesn't crash with nils
+	cur := []*containers.Container{&containers.Container{}}
+	last := []*containers.Container{&containers.Container{}}
+	fmtContainers(cur, last, time.Now(), 10)
+	fmtContainerStats(cur, last, time.Now(), 10)
+
+	// Make sure we get values when we have nils in last.
+	cur = []*containers.Container{
+		&containers.Container{
+			ID:  "1",
+			CPU: &metrics.CgroupTimesStat{},
+		},
+	}
+	last = []*containers.Container{
+		&containers.Container{
+			ID:     "1",
+			Memory: &metrics.CgroupMemStat{},
+		},
+	}
+	fmtContainers(cur, last, time.Now(), 10)
+	fmtContainerStats(cur, last, time.Now(), 10)
+
 }

--- a/checks/process.go
+++ b/checks/process.go
@@ -24,11 +24,11 @@ var Process = &ProcessCheck{}
 type ProcessCheck struct {
 	sync.Mutex
 
-	sysInfo      *model.SystemInfo
-	lastCPUTime  cpu.TimesStat
-	lastProcs    map[int32]*process.FilledProcess
-	lastCtrRates map[string]util.ContainerRateMetrics
-	lastRun      time.Time
+	sysInfo        *model.SystemInfo
+	lastCPUTime    cpu.TimesStat
+	lastProcs      map[int32]*process.FilledProcess
+	lastContainers []*containers.Container
+	lastRun        time.Time
 }
 
 // Init initializes the singleton ProcessCheck.
@@ -71,7 +71,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	if p.lastProcs == nil {
 		p.lastProcs = procs
 		p.lastCPUTime = cpuTimes[0]
-		p.lastCtrRates = util.ExtractContainerRateMetric(ctrList)
+		p.lastContainers = ctrList
 		p.lastRun = time.Now()
 		return nil, nil
 	}
@@ -83,7 +83,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 		return nil, nil
 	}
 	groupSize := len(chunkedProcs)
-	chunkedContainers := fmtContainers(ctrList, p.lastCtrRates, p.lastRun, groupSize)
+	chunkedContainers := fmtContainers(ctrList, p.lastContainers, p.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	totalProcs, totalContainers := float64(0), float64(0)
 	for i := 0; i < groupSize; i++ {
@@ -102,7 +102,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	// Store the last state for comparison on the next run.
 	// Note: not storing the filtered in case there are new processes that haven't had a chance to show up twice.
 	p.lastProcs = procs
-	p.lastCtrRates = util.ExtractContainerRateMetric(ctrList)
+	p.lastContainers = ctrList
 	p.lastCPUTime = cpuTimes[0]
 	p.lastRun = time.Now()
 

--- a/util/containers_common.go
+++ b/util/containers_common.go
@@ -1,19 +1,15 @@
 package util
 
-import "github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+)
 
-// ContainerRateMetrics holds previous values for a container,
-// in order to compute rates
-type ContainerRateMetrics struct {
-	CPU        *metrics.CgroupTimesStat
-	IO         *metrics.CgroupIOStat
-	NetworkSum *metrics.InterfaceNetStats
-}
-
-// NullContainerRates can be safely used for containers that have no
-// previours rate values stored (new containers)
-var NullContainerRates = ContainerRateMetrics{
-	CPU:        &metrics.CgroupTimesStat{},
-	IO:         &metrics.CgroupIOStat{},
-	NetworkSum: &metrics.InterfaceNetStats{},
+// NullContainer can be safely used for containers that have no
+// previours values stored (new containers)
+var NullContainer = &containers.Container{
+	CPU:     &metrics.CgroupTimesStat{},
+	Memory:  &metrics.CgroupMemStat{},
+	IO:      &metrics.CgroupIOStat{},
+	Network: metrics.ContainerNetStats{},
 }

--- a/util/containers_linux.go
+++ b/util/containers_linux.go
@@ -55,18 +55,3 @@ func GetContainers() ([]*containers.Container, error) {
 	log.Tracef("Got %d containers from source %s", len(containers), name)
 	return containers, nil
 }
-
-// ExtractContainerRateMetric extracts relevant rate values from a container list
-// for later reuse, while reducing memory usage to only the needed fields
-func ExtractContainerRateMetric(containers []*containers.Container) map[string]ContainerRateMetrics {
-	out := make(map[string]ContainerRateMetrics)
-	for _, c := range containers {
-		m := ContainerRateMetrics{
-			CPU:        c.CPU,
-			IO:         c.IO,
-			NetworkSum: c.Network.SumInterfaces(),
-		}
-		out[c.ID] = m
-	}
-	return out
-}


### PR DESCRIPTION
Because we need to monitor for containers in other modes other than `NORMAL`, this (https://github.com/DataDog/datadog-agent/pull/2274) doesn't look like the way to go, unfortunately. So let's just be resilient on the process-agent side.

Hopefully the default values for the container model in case the rates are not computable/available are fine for the paused, CNI containers. Pushing this to try to unblock the `6.5.0 rc.2` release.

---

Also switch back to storing the previous container from just the rate metrics. This will simplfiy the interface for setting defaults on nil containers and make it easy to apply it broadly.

The trade-off is maybe more memory but we've had this in all versions up to this point so I'm not too worried about it.

Includes some simple tests that would panic before the code change.