### PR TITLE
Fixing ECS values with nil containers take 2

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -21,9 +21,9 @@ var Container = &ContainerCheck{}
 
 // ContainerCheck is a check that returns container metadata and stats.
 type ContainerCheck struct {
-	sysInfo        *model.SystemInfo
-	lastContainers []*containers.Container
-	lastRun        time.Time
+	sysInfo   *model.SystemInfo
+	lastRates map[string]util.ContainerRateMetrics
+	lastRun   time.Time
 }
 
 // Init initializes a ContainerCheck instance.
@@ -50,8 +50,8 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	}
 
 	// End check early if this is our first run.
-	if c.lastContainers == nil {
-		c.lastContainers = ctrList
+	if c.lastRates == nil {
+		c.lastRates = util.ExtractContainerRateMetric(ctrList)
 		c.lastRun = time.Now()
 		return nil, nil
 	}
@@ -60,7 +60,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	if len(ctrList) != cfg.MaxPerMessage {
 		groupSize++
 	}
-	chunked := fmtContainers(ctrList, c.lastContainers, c.lastRun, groupSize)
+	chunked := fmtContainers(ctrList, c.lastRates, c.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	totalContainers := float64(0)
 	for i := 0; i < groupSize; i++ {
@@ -74,7 +74,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 		})
 	}
 
-	c.lastContainers = ctrList
+	c.lastRates = util.ExtractContainerRateMetric(ctrList)
 	c.lastRun = time.Now()
 
 	statsd.Client.Gauge("datadog.process.containers.host_count", totalContainers, []string{}, 1)
@@ -85,31 +85,23 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 // fmtContainers formats and chunks the ctrList into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
 func fmtContainers(
-	ctrList, lastContainers []*containers.Container,
+	ctrList []*containers.Container,
+	lastRates map[string]util.ContainerRateMetrics,
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.Container {
-	lastByID := make(map[string]*containers.Container, len(ctrList))
-	for _, c := range lastContainers {
-		lastByID[c.ID] = c
-	}
-
 	perChunk := (len(ctrList) / chunks) + 1
 	chunked := make([][]*model.Container, chunks)
 	chunk := make([]*model.Container, 0, perChunk)
 	i := 0
 	for _, ctr := range ctrList {
-		lastCtr, ok := lastByID[ctr.ID]
+		lastCtr, ok := lastRates[ctr.ID]
 		if !ok {
 			// Set to an empty container so rate calculations work and use defaults.
-			lastCtr = util.NullContainer
+			lastCtr = util.NullContainerRates
 		}
 
-		// Just in case the container is found, but refs are nil
-		fillNilContainers(ctr, lastCtr)
-
 		ifStats := ctr.Network.SumInterfaces()
-		lastIfStats := lastCtr.Network.SumInterfaces()
 		cpus := runtime.NumCPU()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
@@ -135,10 +127,10 @@ func fmtContainers(
 			Health:      model.ContainerHealth(model.ContainerHealth_value[ctr.Health]),
 			Rbps:        calculateRate(ctr.IO.ReadBytes, lastCtr.IO.ReadBytes, lastRun),
 			Wbps:        calculateRate(ctr.IO.WriteBytes, lastCtr.IO.WriteBytes, lastRun),
-			NetRcvdPs:   calculateRate(ifStats.PacketsRcvd, lastIfStats.PacketsRcvd, lastRun),
-			NetSentPs:   calculateRate(ifStats.PacketsSent, lastIfStats.PacketsSent, lastRun),
-			NetRcvdBps:  calculateRate(ifStats.BytesRcvd, lastIfStats.BytesRcvd, lastRun),
-			NetSentBps:  calculateRate(ifStats.BytesSent, lastIfStats.BytesSent, lastRun),
+			NetRcvdPs:   calculateRate(ifStats.PacketsRcvd, lastCtr.NetworkSum.PacketsRcvd, lastRun),
+			NetSentPs:   calculateRate(ifStats.PacketsSent, lastCtr.NetworkSum.PacketsSent, lastRun),
+			NetRcvdBps:  calculateRate(ifStats.BytesRcvd, lastCtr.NetworkSum.BytesRcvd, lastRun),
+			NetSentBps:  calculateRate(ifStats.BytesSent, lastCtr.NetworkSum.BytesSent, lastRun),
 			Started:     ctr.StartedAt,
 			Tags:        tags,
 		})
@@ -170,21 +162,4 @@ func calculateCtrPct(cur, prev, sys2, sys1 uint64, numCPU int, before time.Time)
 		return (cpuDelta / sysDelta) * float32(numCPU) * 100
 	}
 	return float32(cur-prev) / float32(diff)
-}
-
-func fillNilContainers(ctrs ...*containers.Container) {
-	for _, c := range ctrs {
-		if c.CPU == nil {
-			c.CPU = util.NullContainer.CPU
-		}
-		if c.Memory == nil {
-			c.Memory = util.NullContainer.Memory
-		}
-		if c.IO == nil {
-			c.IO = util.NullContainer.IO
-		}
-		if c.Network == nil {
-			c.Network = util.NullContainer.Network
-		}
-	}
 }

--- a/checks/container_nolinux.go
+++ b/checks/container_nolinux.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
+	"github.com/DataDog/datadog-process-agent/util"
 )
 
 // Container is a singleton ContainerCheck.
@@ -44,7 +45,8 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 // fmtContainers formats and chunks the containers into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
 func fmtContainers(
-	ctrList, lastContainers []*containers.Container,
+	ctrList []*containers.Container,
+	lastRates map[string]util.ContainerRateMetrics,
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.Container {

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -93,6 +93,10 @@ func fmtContainerStats(
 			lastCtr = util.NullContainerRates
 		}
 
+		// Just in case the container is found, but refs are nil
+		ctr = fillNilContainer(ctr)
+		lastCtr = fillNilRates(lastCtr)
+
 		ifStats := ctr.Network.SumInterfaces()
 		cpus := runtime.NumCPU()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage

--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -18,9 +18,9 @@ var RTContainer = &RTContainerCheck{}
 
 // RTContainerCheck collects numeric statistics about live ctrList.
 type RTContainerCheck struct {
-	sysInfo        *model.SystemInfo
-	lastContainers []*containers.Container
-	lastRun        time.Time
+	sysInfo   *model.SystemInfo
+	lastRates map[string]util.ContainerRateMetrics
+	lastRun   time.Time
 }
 
 // Init initializes a RTContainerCheck instance.
@@ -45,8 +45,8 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	}
 
 	// End check early if this is our first run.
-	if r.lastContainers == nil {
-		r.lastContainers = ctrList
+	if r.lastRates == nil {
+		r.lastRates = util.ExtractContainerRateMetric(ctrList)
 		r.lastRun = time.Now()
 		return nil, nil
 	}
@@ -55,7 +55,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	if len(ctrList) != cfg.MaxPerMessage {
 		groupSize++
 	}
-	chunked := fmtContainerStats(ctrList, r.lastContainers, r.lastRun, groupSize)
+	chunked := fmtContainerStats(ctrList, r.lastRates, r.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	for i := 0; i < groupSize; i++ {
 		messages = append(messages, &model.CollectorContainerRealTime{
@@ -68,7 +68,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 		})
 	}
 
-	r.lastContainers = ctrList
+	r.lastRates = util.ExtractContainerRateMetric(ctrList)
 	r.lastRun = time.Now()
 
 	return messages, nil
@@ -77,31 +77,23 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 // fmtContainerStats formats and chunks the ctrList into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
 func fmtContainerStats(
-	ctrList, lastContainers []*containers.Container,
+	ctrList []*containers.Container,
+	lastRates map[string]util.ContainerRateMetrics,
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.ContainerStat {
-	lastByID := make(map[string]*containers.Container, len(ctrList))
-	for _, c := range lastContainers {
-		lastByID[c.ID] = c
-	}
-
 	perChunk := (len(ctrList) / chunks) + 1
 	chunked := make([][]*model.ContainerStat, chunks)
 	chunk := make([]*model.ContainerStat, 0, perChunk)
 	i := 0
 	for _, ctr := range ctrList {
-		lastCtr, ok := lastByID[ctr.ID]
+		lastCtr, ok := lastRates[ctr.ID]
 		if !ok {
 			// Set to an empty container so rate calculations work and use defaults.
-			lastCtr = util.NullContainer
+			lastCtr = util.NullContainerRates
 		}
 
-		// Just in case the container is found, but refs are nil
-		fillNilContainers(ctr, lastCtr)
-
 		ifStats := ctr.Network.SumInterfaces()
-		lastIfStats := lastCtr.Network.SumInterfaces()
 		cpus := runtime.NumCPU()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 		chunk = append(chunk, &model.ContainerStat{
@@ -115,10 +107,10 @@ func fmtContainerStats(
 			MemLimit:   ctr.MemLimit,
 			Rbps:       calculateRate(ctr.IO.ReadBytes, lastCtr.IO.ReadBytes, lastRun),
 			Wbps:       calculateRate(ctr.IO.WriteBytes, lastCtr.IO.WriteBytes, lastRun),
-			NetRcvdPs:  calculateRate(ifStats.PacketsRcvd, lastIfStats.PacketsRcvd, lastRun),
-			NetSentPs:  calculateRate(ifStats.PacketsSent, lastIfStats.PacketsSent, lastRun),
-			NetRcvdBps: calculateRate(ifStats.BytesRcvd, lastIfStats.BytesRcvd, lastRun),
-			NetSentBps: calculateRate(ifStats.BytesSent, lastIfStats.BytesSent, lastRun),
+			NetRcvdPs:  calculateRate(ifStats.PacketsRcvd, lastCtr.NetworkSum.PacketsRcvd, lastRun),
+			NetSentPs:  calculateRate(ifStats.PacketsSent, lastCtr.NetworkSum.PacketsSent, lastRun),
+			NetRcvdBps: calculateRate(ifStats.BytesRcvd, lastCtr.NetworkSum.BytesRcvd, lastRun),
+			NetSentBps: calculateRate(ifStats.BytesSent, lastCtr.NetworkSum.BytesSent, lastRun),
 			State:      model.ContainerState(model.ContainerState_value[ctr.State]),
 			Health:     model.ContainerHealth(model.ContainerHealth_value[ctr.Health]),
 			Started:    ctr.StartedAt,

--- a/checks/container_rt_nolinux.go
+++ b/checks/container_rt_nolinux.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/model"
+	"github.com/DataDog/datadog-process-agent/util"
 )
 
 // RTContainer is a singleton RTContainerCheck.
@@ -42,7 +43,8 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 // fmtContainerStats formats and chunks the containers into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
 func fmtContainerStats(
-	ctrList, lastContainers []*containers.Container,
+	ctrList []*containers.Container,
+	lastRates map[string]util.ContainerRateMetrics,
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.ContainerStat {

--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-process-agent/util"
 )
 
 func makeContainer(id string) *containers.Container {
@@ -27,25 +29,26 @@ func TestContainerChunking(t *testing.T) {
 	lastRun := time.Now().Add(-5 * time.Second)
 
 	for i, tc := range []struct {
-		cur, last []*containers.Container
-		chunks    int
-		expected  int
+		cur      []*containers.Container
+		last     map[string]util.ContainerRateMetrics
+		chunks   int
+		expected int
 	}{
 		{
 			cur:      []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
-			last:     []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
+			last:     util.ExtractContainerRateMetric([]*containers.Container{ctrs[0], ctrs[1], ctrs[2]}),
 			chunks:   2,
 			expected: 3,
 		},
 		{
 			cur:      []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
-			last:     []*containers.Container{ctrs[0], ctrs[2]},
+			last:     util.ExtractContainerRateMetric([]*containers.Container{ctrs[0], ctrs[2]}),
 			chunks:   2,
 			expected: 3,
 		},
 		{
 			cur:      []*containers.Container{ctrs[0], ctrs[2]},
-			last:     []*containers.Container{ctrs[0], ctrs[1], ctrs[2]},
+			last:     util.ExtractContainerRateMetric([]*containers.Container{ctrs[0], ctrs[1], ctrs[2]}),
 			chunks:   20,
 			expected: 2,
 		},
@@ -67,29 +70,4 @@ func TestContainerChunking(t *testing.T) {
 		assert.Equal(t, tc.expected, total, "total test %d", i)
 
 	}
-}
-
-func TestContainerNils(t *testing.T) {
-	// Make sure formatting doesn't crash with nils
-	cur := []*containers.Container{&containers.Container{}}
-	last := []*containers.Container{&containers.Container{}}
-	fmtContainers(cur, last, time.Now(), 10)
-	fmtContainerStats(cur, last, time.Now(), 10)
-
-	// Make sure we get values when we have nils in last.
-	cur = []*containers.Container{
-		&containers.Container{
-			ID:  "1",
-			CPU: &metrics.CgroupTimesStat{},
-		},
-	}
-	last = []*containers.Container{
-		&containers.Container{
-			ID:     "1",
-			Memory: &metrics.CgroupMemStat{},
-		},
-	}
-	fmtContainers(cur, last, time.Now(), 10)
-	fmtContainerStats(cur, last, time.Now(), 10)
-
 }

--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -71,3 +71,25 @@ func TestContainerChunking(t *testing.T) {
 
 	}
 }
+
+func TestContainerNils(t *testing.T) {
+	// Make sure formatting doesn't crash with nils
+	cur := []*containers.Container{&containers.Container{}}
+	last := map[string]util.ContainerRateMetrics{}
+	fmtContainers(cur, last, time.Now(), 10)
+	fmtContainerStats(cur, last, time.Now(), 10)
+	// Make sure we get values when we have nils in last.
+	cur = []*containers.Container{
+		&containers.Container{
+			ID:  "1",
+			CPU: &metrics.CgroupTimesStat{},
+		},
+	}
+	last = map[string]util.ContainerRateMetrics{
+		"1": util.ContainerRateMetrics{
+			CPU: &metrics.CgroupTimesStat{},
+		},
+	}
+	fmtContainers(cur, last, time.Now(), 10)
+	fmtContainerStats(cur, last, time.Now(), 10)
+}

--- a/checks/process.go
+++ b/checks/process.go
@@ -24,11 +24,11 @@ var Process = &ProcessCheck{}
 type ProcessCheck struct {
 	sync.Mutex
 
-	sysInfo        *model.SystemInfo
-	lastCPUTime    cpu.TimesStat
-	lastProcs      map[int32]*process.FilledProcess
-	lastContainers []*containers.Container
-	lastRun        time.Time
+	sysInfo      *model.SystemInfo
+	lastCPUTime  cpu.TimesStat
+	lastProcs    map[int32]*process.FilledProcess
+	lastCtrRates map[string]util.ContainerRateMetrics
+	lastRun      time.Time
 }
 
 // Init initializes the singleton ProcessCheck.
@@ -71,7 +71,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	if p.lastProcs == nil {
 		p.lastProcs = procs
 		p.lastCPUTime = cpuTimes[0]
-		p.lastContainers = ctrList
+		p.lastCtrRates = util.ExtractContainerRateMetric(ctrList)
 		p.lastRun = time.Now()
 		return nil, nil
 	}
@@ -83,7 +83,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 		return nil, nil
 	}
 	groupSize := len(chunkedProcs)
-	chunkedContainers := fmtContainers(ctrList, p.lastContainers, p.lastRun, groupSize)
+	chunkedContainers := fmtContainers(ctrList, p.lastCtrRates, p.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	totalProcs, totalContainers := float64(0), float64(0)
 	for i := 0; i < groupSize; i++ {
@@ -102,7 +102,7 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	// Store the last state for comparison on the next run.
 	// Note: not storing the filtered in case there are new processes that haven't had a chance to show up twice.
 	p.lastProcs = procs
-	p.lastContainers = ctrList
+	p.lastCtrRates = util.ExtractContainerRateMetric(ctrList)
 	p.lastCPUTime = cpuTimes[0]
 	p.lastRun = time.Now()
 

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -18,11 +18,11 @@ var RTProcess = &RTProcessCheck{}
 // RTProcessCheck collects numeric statistics about the live processes.
 // The instance stores state between checks for calculation of rates and CPU.
 type RTProcessCheck struct {
-	sysInfo        *model.SystemInfo
-	lastCPUTime    cpu.TimesStat
-	lastProcs      map[int32]*process.FilledProcess
-	lastContainers []*containers.Container
-	lastRun        time.Time
+	sysInfo      *model.SystemInfo
+	lastCPUTime  cpu.TimesStat
+	lastProcs    map[int32]*process.FilledProcess
+	lastCtrRates map[string]util.ContainerRateMetrics
+	lastRun      time.Time
 }
 
 // Init initializes a new RTProcessCheck instance.
@@ -58,7 +58,7 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 
 	// End check early if this is our first run.
 	if r.lastProcs == nil {
-		r.lastContainers = ctrList
+		r.lastCtrRates = util.ExtractContainerRateMetric(ctrList)
 		r.lastProcs = procs
 		r.lastCPUTime = cpuTimes[0]
 		r.lastRun = time.Now()
@@ -68,7 +68,7 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	chunkedStats := fmtProcessStats(cfg, procs, r.lastProcs,
 		ctrList, cpuTimes[0], r.lastCPUTime, r.lastRun)
 	groupSize := len(chunkedStats)
-	chunkedCtrStats := fmtContainerStats(ctrList, r.lastContainers, r.lastRun, groupSize)
+	chunkedCtrStats := fmtContainerStats(ctrList, r.lastCtrRates, r.lastRun, groupSize)
 	messages := make([]model.MessageBody, 0, groupSize)
 	for i := 0; i < groupSize; i++ {
 		messages = append(messages, &model.CollectorRealTime{
@@ -86,7 +86,7 @@ func (r *RTProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	// Note: not storing the filtered in case there are new processes that haven't had a chance to show up twice.
 	r.lastRun = time.Now()
 	r.lastProcs = procs
-	r.lastContainers = ctrList
+	r.lastCtrRates = util.ExtractContainerRateMetric(ctrList)
 	r.lastCPUTime = cpuTimes[0]
 
 	return messages, nil

--- a/util/containers_common.go
+++ b/util/containers_common.go
@@ -8,6 +8,7 @@ type ContainerRateMetrics struct {
 	CPU        *metrics.CgroupTimesStat
 	IO         *metrics.CgroupIOStat
 	NetworkSum *metrics.InterfaceNetStats
+	Network    metrics.ContainerNetStats
 }
 
 // NullContainerRates can be safely used for containers that have no
@@ -16,4 +17,5 @@ var NullContainerRates = ContainerRateMetrics{
 	CPU:        &metrics.CgroupTimesStat{},
 	IO:         &metrics.CgroupIOStat{},
 	NetworkSum: &metrics.InterfaceNetStats{},
+	Network:    metrics.ContainerNetStats{},
 }

--- a/util/containers_common.go
+++ b/util/containers_common.go
@@ -1,15 +1,19 @@
 package util
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
-)
+import "github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 
-// NullContainer can be safely used for containers that have no
-// previours values stored (new containers)
-var NullContainer = &containers.Container{
-	CPU:     &metrics.CgroupTimesStat{},
-	Memory:  &metrics.CgroupMemStat{},
-	IO:      &metrics.CgroupIOStat{},
-	Network: metrics.ContainerNetStats{},
+// ContainerRateMetrics holds previous values for a container,
+// in order to compute rates
+type ContainerRateMetrics struct {
+	CPU        *metrics.CgroupTimesStat
+	IO         *metrics.CgroupIOStat
+	NetworkSum *metrics.InterfaceNetStats
+}
+
+// NullContainerRates can be safely used for containers that have no
+// previours rate values stored (new containers)
+var NullContainerRates = ContainerRateMetrics{
+	CPU:        &metrics.CgroupTimesStat{},
+	IO:         &metrics.CgroupIOStat{},
+	NetworkSum: &metrics.InterfaceNetStats{},
 }

--- a/util/containers_linux.go
+++ b/util/containers_linux.go
@@ -55,3 +55,18 @@ func GetContainers() ([]*containers.Container, error) {
 	log.Tracef("Got %d containers from source %s", len(containers), name)
 	return containers, nil
 }
+
+// ExtractContainerRateMetric extracts relevant rate values from a container list
+// for later reuse, while reducing memory usage to only the needed fields
+func ExtractContainerRateMetric(containers []*containers.Container) map[string]ContainerRateMetrics {
+	out := make(map[string]ContainerRateMetrics)
+	for _, c := range containers {
+		m := ContainerRateMetrics{
+			CPU:        c.CPU,
+			IO:         c.IO,
+			NetworkSum: c.Network.SumInterfaces(),
+		}
+		out[c.ID] = m
+	}
+	return out
+}

--- a/util/containers_nolinux.go
+++ b/util/containers_nolinux.go
@@ -15,3 +15,9 @@ func SetContainerSource(name string) {
 func GetContainers() ([]*containers.Container, error) {
 	return nil, ErrNotImplemented
 }
+
+// ExtractContainerRateMetric extracts relevant rate values from a container list
+// for later reuse, while reducing memory usage to only the needed fields
+func ExtractContainerRateMetric(containers []*containers.Container) map[string]ContainerRateMetrics {
+	return nil
+}


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/DataDog/datadog-process-agent/pull/176 which meant that we would have `NaN` values. The summary is that since we cache the container object we can't use the pointer to that object as the `lastContainers` value anymore.

This includes a revert of yesterday's change + the actual change in https://github.com/DataDog/datadog-process-agent/commit/e742ae8f8be3cfbaf432240032a2fb9d3d8cc032.