### PR TITLE
Install mercurial in build job image, and update default net socket location

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ var (
 
 	// defaultNetworkTracerSocketPath is the default unix socket path to be used for connecting to the network tracer
 	// This mirrors the default location defined in the tcptracer-bpf library
-	defaultNetworkTracerSocketPath = "/var/run/datadog/nettracer.sock"
+	defaultNetworkTracerSocketPath = "/opt/datadog-agent/run/nettracer.sock"
 
 	processChecks   = []string{"process", "rtprocess"}
 	containerChecks = []string{"container", "rtcontainer"}

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     apt-add-repository ppa:brightbox/ruby-ng && \
     apt-get update && \
     apt-get install -y build-essential debhelper git gnupg rake curl devscripts ruby-dev zlib1g-dev libxml2-dev wget rpm debsigs expect ruby2.3 ruby2.3-dev createrepo python-dateutil python-dev 
-RUN apt-get install -y linux-headers-generic
+RUN apt-get install -y linux-headers-generic mercurial
 
 RUN gem install deb-s3 inifile
 


### PR DESCRIPTION
Updating socket location per: https://github.com/DataDog/datadog-agent/pull/2236#issuecomment-419479758

Mercurial needed due to glide. I've already uploaded the updated image.