### PR TITLE
[windows-only] Fix handling of container formatting

### DIFF
--- a/checks/container_nolinux.go
+++ b/checks/container_nolinux.go
@@ -50,5 +50,5 @@ func fmtContainers(
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.Container {
-	return nil
+	return make([][]*model.Container, chunks)
 }

--- a/checks/container_rt_nolinux.go
+++ b/checks/container_rt_nolinux.go
@@ -48,5 +48,5 @@ func fmtContainerStats(
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.ContainerStat {
-	return nil
+	return make([][]*model.ContainerStat, chunks)
 }


### PR DESCRIPTION
We expect this function to return a slice of size `chunks` to avoid this index out of range:

```
goroutine 1 [running]:
github.com/DataDog/datadog-process-agent/checks.(*ProcessCheck).Run(0xef0940, 0xc042085ba0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0
)
        c:/dev/go/src/github.com/DataDog/datadog-process-agent/checks/process.go:91 +0xaca
main.printResults(0xc042085ba0, 0xb8fc40, 0xef0940, 0xc042174901, 0x0)
        c:/dev/go/src/github.com/DataDog/datadog-process-agent/agent/main_common.go:237 +0x250
main.debugCheckResults(0xc042085ba0, 0xc04201e0b8, 0x7, 0x0, 0x0)
        c:/dev/go/src/github.com/DataDog/datadog-process-agent/agent/main_common.go:213 +0x28f
main.runAgent(0xc04204e660)
        c:/dev/go/src/github.com/DataDog/datadog-process-agent/agent/main_common.go:161 +0x859
main.main()
        c:/dev/go/src/github.com/DataDog/datadog-process-agent/agent/main_windows.go:190 +0x449

C:\Program Files\Datadog\Datadog Agent\bin\agent>process-agent -check process
```