### PR TITLE
Support running on 32bit ARM platform

### DIFF
--- a/cmd/agent/collector.go
+++ b/cmd/agent/collector.go
@@ -31,14 +31,14 @@ type Collector struct {
 	cfg           *config.AgentConfig
 	httpClient    http.Client
 	groupID       int32
-	runCounter    int64
+	runCounter    int32
 	enabledChecks []checks.Check
 
 	// Controls the real-time interval, can change live.
 	realTimeInterval time.Duration
 	// Set to 1 if enabled 0 is not. We're using an integer
 	// so we can use the sync/atomic for thread-safe access.
-	realTimeEnabled int64
+	realTimeEnabled int32
 }
 
 // NewCollector creates a new Collector
@@ -71,7 +71,7 @@ func NewCollector(cfg *config.AgentConfig) (Collector, error) {
 }
 
 func (l *Collector) runCheck(c checks.Check) {
-	runCounter := atomic.AddInt64(&l.runCounter, 1)
+	runCounter := atomic.AddInt32(&l.runCounter, 1)
 	s := time.Now()
 	// update the last collected timestamp for info
 	updateLastCollectTime(time.Now())
@@ -139,7 +139,7 @@ func (l *Collector) run(exit chan bool) {
 			for {
 				select {
 				case <-ticker.C:
-					realTimeEnabled := atomic.LoadInt64(&l.realTimeEnabled) == 1
+					realTimeEnabled := atomic.LoadInt32(&l.realTimeEnabled) == 1
 					if !c.RealTime() || realTimeEnabled {
 						l.runCheck(c)
 					}
@@ -212,7 +212,7 @@ func (l *Collector) postMessage(checkPath string, m model.MessageBody) {
 }
 
 func (l *Collector) updateStatus(statuses []*model.CollectorStatus) {
-	curEnabled := atomic.LoadInt64(&l.realTimeEnabled) == 1
+	curEnabled := atomic.LoadInt32(&l.realTimeEnabled) == 1
 
 	// If any of the endpoints wants real-time we'll do that.
 	// We will pick the maximum interval given since generally this is
@@ -229,10 +229,10 @@ func (l *Collector) updateStatus(statuses []*model.CollectorStatus) {
 
 	if curEnabled && !shouldEnableRT {
 		log.Info("Detected 0 clients, disabling real-time mode")
-		atomic.StoreInt64(&l.realTimeEnabled, 0)
+		atomic.StoreInt32(&l.realTimeEnabled, 0)
 	} else if !curEnabled && shouldEnableRT {
 		log.Info("Detected active clients, enabling real-time mode")
-		atomic.StoreInt64(&l.realTimeEnabled, 1)
+		atomic.StoreInt32(&l.realTimeEnabled, 1)
 	}
 
 	if maxInterval != l.realTimeInterval {

--- a/cmd/agent/collector_test.go
+++ b/cmd/agent/collector_test.go
@@ -25,7 +25,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 0, Interval: 2},
 	}
 	c.updateStatus(statuses)
-	assert.Equal(int64(1), atomic.LoadInt64(&c.realTimeEnabled))
+	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
 
 	// Validate that we stay that way
 	statuses = []*model.CollectorStatus{
@@ -34,7 +34,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 0, Interval: 2},
 	}
 	c.updateStatus(statuses)
-	assert.Equal(int64(1), atomic.LoadInt64(&c.realTimeEnabled))
+	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
 
 	// And that it can turn back off
 	statuses = []*model.CollectorStatus{
@@ -43,7 +43,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 0, Interval: 2},
 	}
 	c.updateStatus(statuses)
-	assert.Equal(int64(0), atomic.LoadInt64(&c.realTimeEnabled))
+	assert.Equal(int32(0), atomic.LoadInt32(&c.realTimeEnabled))
 }
 
 func TestUpdateRTInterval(t *testing.T) {
@@ -61,6 +61,6 @@ func TestUpdateRTInterval(t *testing.T) {
 		{ActiveClients: 0, Interval: 10},
 	}
 	c.updateStatus(statuses)
-	assert.Equal(int64(1), atomic.LoadInt64(&c.realTimeEnabled))
+	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
 	assert.Equal(10*time.Second, c.realTimeInterval)
 }


### PR DESCRIPTION
On 32 bits system like armv7 (raspberry pi), using `atomic.AddInt64` (and other variants) resulted in a nil pointer exception. I understand datadog does not officially support arm, but since the fix is pretty easy in this case, it seemed like a good candidate for a PR.

This go issue has more details https://github.com/golang/go/issues/599

In our case we make limited use of 64 bits atomic functions, in two places:
- `runCounter`: This is only used for logging and assuming an increment each second would overflow in 70 years if 32 bits, so is most likely safe
- `realTimeEnabled`: This is used as a pseudo bolean so 0/1 and is safe

I've recompiled the agent 6.5.2 from source using this fix and I'm successfully running it on my Raspberry Pi, with processes reporting.

For the record, log output without the fix:
```
Oct 14 22:26:18 unifi systemd[1]: Started "Datadog Process Agent".
Oct 14 22:26:18 unifi process-agent[15985]: 2018-10-14 22:26:18 INFO (proc.go:210) - pid '15985' written to pid file '/opt/datadog-agent/run/process-agent.pid'
Oct 14 22:26:18 unifi process-agent[15985]: 2018-10-14 22:26:18 INFO (config.go:417) - config.Load()
Oct 14 22:26:18 unifi process-agent[15985]: 2018-10-14 22:26:18 INFO (config.go:426) - config.load succeeded
Oct 14 22:26:18 unifi process-agent[15985]: 2018-10-14 22:26:18 INFO (tagger.go:81) - starting the tagging system
Oct 14 22:26:20 unifi process-agent[15985]: panic: runtime error: invalid memory address or nil pointer dereference
Oct 14 22:26:20 unifi process-agent[15985]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13a88]
Oct 14 22:26:20 unifi process-agent[15985]: goroutine 99 [running]:
Oct 14 22:26:20 unifi process-agent[15985]: runtime/internal/atomic.goXadd64(0x2cb40cc, 0x1, 0x0, 0x0, 0x0)
Oct 14 22:26:20 unifi process-agent[15985]:         /usr/local/go/src/runtime/internal/atomic/atomic_arm.go:96 +0x1c
Oct 14 22:26:20 unifi process-agent[15985]: main.(*Collector).runCheck(0x2cb40a0, 0x10975a0, 0x1c0a2c8)
Oct 14 22:26:20 unifi process-agent[15985]:         /opt/agent/go/src/github.com/DataDog/datadog-process-agent/agent/collector.go:74 +0x38
Oct 14 22:26:20 unifi process-agent[15985]: main.(*Collector).run.func2(0x2cb40a0, 0x2a9ef80, 0x10975a0, 0x1c0a2c8)
Oct 14 22:26:20 unifi systemd[1]: datadog-agent-process.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Oct 14 22:26:20 unifi systemd[1]: datadog-agent-process.service: Unit entered failed state.
Oct 14 22:26:20 unifi systemd[1]: datadog-agent-process.service: Failed with result 'exit-code'.
```