### PR TITLE
Network tracer agent config changes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -406,6 +406,15 @@ func NewNetworkAgentConfig(networkYaml *YamlAgentConfig) (*AgentConfig, error) {
 	cfg := NewDefaultAgentConfig()
 	var err error
 
+	// When the network-tracer is enabled in a separate container, we need a way to also disable the network-tracer
+	// packaged in the main agent container (without disabling network collection on the process-agent).
+	//
+	// If this environment flag is set, it'll sure it will not start
+	if ok, _ := isAffirmative(os.Getenv("DD_NETWORK_TRACING_EXTERNAL")); ok {
+		cfg.EnableNetworkTracing = false
+		return cfg, nil
+	}
+
 	if networkYaml != nil {
 		if cfg, err = mergeNetworkYamlConfig(cfg, networkYaml); err != nil {
 			return nil, fmt.Errorf("failed to parse config: %s", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -502,7 +502,7 @@ func TestDDAgentConfigYamlAndNetworkConfig(t *testing.T) {
 	var netYamlConf YamlAgentConfig
 	err = yaml.Unmarshal([]byte(strings.Join([]string{
 		"network_tracer_config:",
-		"  network_tracing_enabled: 'true'",
+		"  enabled: true",
 		"  nettracer_socket: /var/my-location/network-tracer.log",
 	}, "\n")), &netYamlConf)
 	assert.NoError(err)

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -77,7 +77,7 @@ type YamlAgentConfig struct {
 	// Network-tracing specific configuration
 	Network struct {
 		// A string indicating the enabled state of the network tracer.
-		NetworkTracingEnabled string `yaml:"network_tracing_enabled"`
+		NetworkTracingEnabled bool `yaml:"enabled"`
 		// The full path to the location of the unix socket where network traces will be accessed
 		UnixSocketPath string `yaml:"nettracer_socket"`
 		// The full path to the file where network-tracer logs will be written.
@@ -217,9 +217,9 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 }
 
 func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *YamlAgentConfig) (*AgentConfig, error) {
-	if enabled, _ := isAffirmative(networkConf.Network.NetworkTracingEnabled); enabled {
+	if networkConf.Network.NetworkTracingEnabled {
 		agentConf.EnabledChecks = append(agentConf.EnabledChecks, "connections")
-		agentConf.EnableNetworkTracing = enabled
+		agentConf.EnableNetworkTracing = true
 	}
 	if socketPath := networkConf.Network.UnixSocketPath; socketPath != "" {
 		agentConf.NetworkTracerSocketPath = socketPath


### PR DESCRIPTION
- Changing the way we enable the network-tracer agent to not need a string `"true"/"false"` value, as it's very inconsistent with the rest of the agent's configuration.
- Add an environment flag that we can use to disable the network-tracer agent, if its being run in a separate container for security reasons.