### PR TITLE
Prevent uint underflows when calculating rates and percentages

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -159,9 +159,14 @@ func calculateCtrPct(cur, prev, sys2, sys1 uint64, numCPU int, before time.Time)
 		return 0
 	}
 
+	// Prevent uint underflows
+	if prev > cur || sys1 > sys2 {
+		return 0
+	}
+
 	// If we have system usage values then we need to calculate against those.
 	// XXX: Right now this only applies to ECS collection
-	if sys1 > 0 && sys2 > 0 {
+	if sys1 > 0 && sys2 > 0 && sys2 != sys1 {
 		cpuDelta := float32(cur - prev)
 		sysDelta := float32(sys2 - sys1)
 		return (cpuDelta / sysDelta) * float32(numCPU) * 100

--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -93,3 +93,32 @@ func TestContainerNils(t *testing.T) {
 	fmtContainers(cur, last, time.Now(), 10)
 	fmtContainerStats(cur, last, time.Now(), 10)
 }
+
+func TestCalculateCtrPct(t *testing.T) {
+	epsilon := 0.0000001 // Difference less than some epsilon
+
+	before := time.Now().Add(-1 * time.Second)
+
+	var emptyTime time.Time
+
+	// Underflow on cur-prev
+	assert.Equal(t, float32(0), calculateCtrPct(0, 1, 0, 0, 1, before))
+
+	// Underflow on sys2-sys1
+	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 4, 5, 1, before))
+
+	// Time is empty
+	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 0, 0, 1, emptyTime))
+
+	// Elapsed time is less than 1s
+	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 0, 0, 1, time.Now()))
+
+	// Div by zero on sys2/sys1, fallback to normal cpu calculation
+	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 1, 1, 1, before), epsilon)
+
+	// Calculate based off cur & prev
+	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 0, 0, 1, before), epsilon)
+
+	// Calculate based off all values
+	assert.InEpsilon(t, 66.66667, calculateCtrPct(3, 1, 4, 1, 1, before), epsilon)
+}

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -142,7 +142,7 @@ func fmtProcessStats(
 func calculateRate(cur, prev uint64, before time.Time) float32 {
 	now := time.Now()
 	diff := now.Unix() - before.Unix()
-	if before.IsZero() || diff <= 0 || prev == 0 {
+	if before.IsZero() || diff <= 0 || prev == 0 || prev > cur {
 		return 0
 	}
 	return float32(cur-prev) / float32(diff)

--- a/checks/process_test.go
+++ b/checks/process_test.go
@@ -135,6 +135,9 @@ func TestRateCalculation(t *testing.T) {
 	assert.True(t, floatEquals(calculateRate(5, 1, now), 0))
 	assert.True(t, floatEquals(calculateRate(5, 0, prev), 0))
 	assert.True(t, floatEquals(calculateRate(5, 1, empty), 0))
+
+	// Underflow on cur - prev
+	assert.True(t, floatEquals(calculateRate(0, 1, prev), 0))
 }
 
 func floatEquals(a, b float32) bool {


### PR DESCRIPTION
This PR addresses the scenario where some metrics were being reported as impossibly large values.

The cause here was unsigned integer underflow as when we calculate the "rate" for a given metric, we calculate `(current - previous) / elapsed time in seconds`.  In our case,  `current` and `previous` are usually unsigned integers so if `previous > current`, the subtraction operation will overflow.

This usually only occurs in corner cases where the container metrics were not able to be collected for some reason, possibly because the container is shutting down.