### PR TITLE
UDP, TCP, & IPv6 collection can now be disabled by configuration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,11 +90,11 @@
   revision = "771928d86fa878b9d62f073a7a6f91ee0a358105"
 
 [[projects]]
-  digest = "1:1b855559c94fbc581f1e3908e57af98954cb1d1735755cfb5e109266c6b1d6df"
+  digest = "1:8ed3148707413b4fed2278efd6aa3a1a6da7fa64eb3a171eae0b1a5c5b7d4a25"
   name = "github.com/DataDog/tcptracer-bpf"
   packages = ["pkg/tracer"]
   pruneopts = ""
-  revision = "dcbaab0aacf699bb5613badb063ae4f6dcf1cf66"
+  revision = "f98ab001ca4cb27a853cbe702623d698cd738fd1"
 
 [[projects]]
   digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,11 +90,11 @@
   revision = "771928d86fa878b9d62f073a7a6f91ee0a358105"
 
 [[projects]]
-  digest = "1:8ed3148707413b4fed2278efd6aa3a1a6da7fa64eb3a171eae0b1a5c5b7d4a25"
+  digest = "1:6d949a9cb13d4d91f8d92ae4c888ad4cbe7ed77f7e51abd5bb2453a0d900a08d"
   name = "github.com/DataDog/tcptracer-bpf"
   packages = ["pkg/tracer"]
   pruneopts = ""
-  revision = "f98ab001ca4cb27a853cbe702623d698cd738fd1"
+  revision = "fe34678324074952a5978a561e2b650e414d5ac9"
 
 [[projects]]
   digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,11 +90,11 @@
   revision = "771928d86fa878b9d62f073a7a6f91ee0a358105"
 
 [[projects]]
-  digest = "1:a21bde80219999ce6a26f8b41d0218d77e067628352f88d7173302cf6779d7eb"
+  digest = "1:1b855559c94fbc581f1e3908e57af98954cb1d1735755cfb5e109266c6b1d6df"
   name = "github.com/DataDog/tcptracer-bpf"
   packages = ["pkg/tracer"]
   pruneopts = ""
-  revision = "1281e95bac1df91e307a0cb6795e1c7c76f49067"
+  revision = "dcbaab0aacf699bb5613badb063ae4f6dcf1cf66"
 
 [[projects]]
   digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"
@@ -1008,7 +1008,6 @@
     "github.com/shirou/w32",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
-    "golang.org/x/sys/unix",
     "golang.org/x/sys/windows/svc",
     "golang.org/x/sys/windows/svc/debug",
     "golang.org/x/sys/windows/svc/eventlog",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/tcptracer-bpf"
-  revision = "1281e95bac1df91e307a0cb6795e1c7c76f49067"
+  revision = "dcbaab0aacf699bb5613badb063ae4f6dcf1cf66"
 
 [[constraint]]
   name = "github.com/gogo/protobuf"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/tcptracer-bpf"
-  revision = "dcbaab0aacf699bb5613badb063ae4f6dcf1cf66"
+  revision = "f98ab001ca4cb27a853cbe702623d698cd738fd1"
 
 [[constraint]]
   name = "github.com/gogo/protobuf"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/tcptracer-bpf"
-  revision = "f98ab001ca4cb27a853cbe702623d698cd738fd1"
+  revision = "fe34678324074952a5978a561e2b650e414d5ac9"
 
 [[constraint]]
   name = "github.com/gogo/protobuf"

--- a/checks/net.go
+++ b/checks/net.go
@@ -48,7 +48,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 			return
 		}
 
-		t, err := tracer.NewTracer(tracer.DefaultConfig)
+		t, err := tracer.NewTracer(config.TracerConfigFromConfig(cfg))
 		if err != nil {
 			log.Errorf("failed to create network tracer: %s", err)
 			return

--- a/cmd/network-tracer/tracer.go
+++ b/cmd/network-tracer/tracer.go
@@ -40,7 +40,8 @@ func CreateNetworkTracer(cfg *config.AgentConfig) (*NetworkTracer, error) {
 	}
 
 	log.Infof("Creating tracer for: %s", filepath.Base(os.Args[0]))
-	t, err := tracer.NewTracer(tracer.DefaultConfig)
+
+	t, err := tracer.NewTracer(config.TracerConfigFromConfig(cfg))
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,9 @@ type AgentConfig struct {
 	// Network collection configuration
 	EnableNetworkTracing     bool
 	EnableLocalNetworkTracer bool // To have the network tracer embedded in the process-agent
+	DisableTCPTracing        bool
+	DisableUDPTracing        bool
+	DisableIPv6Tracing       bool
 	NetworkTracerSocketPath  string
 	NetworkTracerLogFile     string
 
@@ -176,6 +179,9 @@ func NewDefaultAgentConfig() *AgentConfig {
 		// Network collection configuration
 		EnableNetworkTracing:     false,
 		EnableLocalNetworkTracer: false,
+		DisableTCPTracing:        false,
+		DisableUDPTracing:        false,
+		DisableIPv6Tracing:       false,
 		NetworkTracerSocketPath:  defaultNetworkTracerSocketPath,
 		NetworkTracerLogFile:     defaultNetworkLogFilePath,
 
@@ -566,6 +572,15 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 	}
 	if ok, _ := isAffirmative(os.Getenv("DD_USE_LOCAL_NETWORK_TRACER")); ok {
 		c.EnableLocalNetworkTracer = ok
+	}
+	if ok, _ := isAffirmative(os.Getenv("DD_DISABLE_TCP_TRACING")); ok {
+		c.DisableTCPTracing = ok
+	}
+	if ok, _ := isAffirmative(os.Getenv("DD_DISABLE_UDP_TRACING")); ok {
+		c.DisableUDPTracing = ok
+	}
+	if ok, _ := isAffirmative(os.Getenv("DD_DISABLE_IPV6_TRACING")); ok {
+		c.DisableIPv6Tracing = ok
 	}
 
 	return c

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -521,6 +521,37 @@ func TestDDAgentConfigYamlAndNetworkConfig(t *testing.T) {
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	assert.Equal("/var/my-location/network-tracer.log", agentConfig.NetworkTracerSocketPath)
 	assert.Equal(append(processChecks, "connections"), agentConfig.EnabledChecks)
+	assert.False(agentConfig.DisableTCPTracing)
+	assert.False(agentConfig.DisableUDPTracing)
+	assert.False(agentConfig.DisableIPv6Tracing)
+
+	err = yaml.Unmarshal([]byte(strings.Join([]string{
+		"network_tracer_config:",
+		"  enabled: true",
+		"  nettracer_socket: /var/my-location/network-tracer.log",
+		"  disable_tcp: true",
+		"  disable_udp: true",
+		"  disable_ipv6: true",
+	}, "\n")), &netYamlConf)
+	assert.NoError(err)
+
+	agentConfig, err = NewAgentConfig(nil, &ddy, &netYamlConf)
+
+	assert.Equal("apikey_20", ep.APIKey)
+	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
+	assert.Equal(10, agentConfig.QueueSize)
+	assert.Equal(true, agentConfig.AllowRealTime)
+	assert.Equal(true, agentConfig.Enabled)
+	assert.Equal(8*time.Second, agentConfig.CheckIntervals["container"])
+	assert.Equal(30*time.Second, agentConfig.CheckIntervals["process"])
+	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
+	assert.Equal(false, agentConfig.Windows.AddNewArgs)
+	assert.Equal(false, agentConfig.Scrubber.Enabled)
+	assert.Equal("/var/my-location/network-tracer.log", agentConfig.NetworkTracerSocketPath)
+	assert.Equal(append(processChecks, "connections"), agentConfig.EnabledChecks)
+	assert.True(agentConfig.DisableTCPTracing)
+	assert.True(agentConfig.DisableUDPTracing)
+	assert.True(agentConfig.DisableIPv6Tracing)
 }
 
 func TestProxyEnv(t *testing.T) {

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"github.com/DataDog/tcptracer-bpf/pkg/tracer"
+	log "github.com/cihub/seelog"
+)
+
+func TracerConfigFromConfig(cfg *AgentConfig) *tracer.Config {
+	tracerConfig := tracer.NewDefaultConfig()
+
+	if !tracerConfig.TraceIPv6Connections {
+		log.Info("network tracer IPv6 tracing disabled by network-tracer")
+	} else if cfg.DisableIPv6Tracing {
+		tracerConfig.TraceIPv6Connections = false
+		log.Info("network tracer IPv6 tracing disabled by configuration")
+	}
+
+	if cfg.DisableUDPTracing {
+		tracerConfig.CollectUDPConns = false
+		log.Info("network tracer UDP tracing disabled by configuration")
+	}
+
+	if cfg.DisableTCPTracing {
+		tracerConfig.CollectTCPConns = false
+		log.Info("network tracer TCP tracing disabled by configuration")
+	}
+
+	return tracerConfig
+}

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -5,6 +5,7 @@ import (
 	log "github.com/cihub/seelog"
 )
 
+// TracerConfigFromConfig returns a valid tcptracer-bpf config sourced from our agent config
 func TracerConfigFromConfig(cfg *AgentConfig) *tracer.Config {
 	tracerConfig := tracer.NewDefaultConfig()
 

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -10,7 +10,7 @@ func TracerConfigFromConfig(cfg *AgentConfig) *tracer.Config {
 	tracerConfig := tracer.NewDefaultConfig()
 
 	if !tracerConfig.TraceIPv6Connections {
-		log.Info("network tracer IPv6 tracing disabled by network-tracer")
+		log.Info("network tracer IPv6 tracing disabled by system")
 	} else if cfg.DisableIPv6Tracing {
 		tracerConfig.TraceIPv6Connections = false
 		log.Info("network tracer IPv6 tracing disabled by configuration")

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -82,6 +82,12 @@ type YamlAgentConfig struct {
 		UnixSocketPath string `yaml:"nettracer_socket"`
 		// The full path to the file where network-tracer logs will be written.
 		LogFile string `yaml:"log_file"`
+		// Whether agent should disable collection for TCP connection type
+		DisableTCP bool `yaml:"disable_tcp"`
+		// Whether agent should disable collection for UDP connection type
+		DisableUDP bool `yaml:"disable_udp"`
+		// Whether agent should disable collection for IPv6 connection type
+		DisableIPv6 bool `yaml:"disable_ipv6"`
 	} `yaml:"network_tracer_config"`
 }
 
@@ -217,6 +223,10 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 }
 
 func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *YamlAgentConfig) (*AgentConfig, error) {
+	agentConf.DisableTCPTracing = networkConf.Network.DisableTCP
+	agentConf.DisableUDPTracing = networkConf.Network.DisableUDP
+	agentConf.DisableIPv6Tracing = networkConf.Network.DisableIPv6
+
 	if networkConf.Network.NetworkTracingEnabled {
 		agentConf.EnabledChecks = append(agentConf.EnabledChecks, "connections")
 		agentConf.EnableNetworkTracing = true


### PR DESCRIPTION
Use the new version of the tcptracer-bpf library, while also exposing some of the configuration options added to disable collection for TCP, UDP, or IPv6 connections.

**Running new network-tracer on system with IPv6 disabled:**
```
2018-11-20 05:21:32 INFO (tracer.go:42) - Creating tracer for: network-tracer-amd64-ipv6_test
2018-11-20 05:21:32 INFO (tracer_config.go:13) - network tracer IPv6 tracing disabled by system
2018-11-20 05:21:33 INFO (main.go:92) - network tracer started
```

**Running previous network-tracer on system with IPv6 disabled:**
```
2018-11-20 04:30:12 INFO (tracer.go:42) - Creating tracer for: network-tracer-amd64-master
2018-11-20 04:30:13 CRITICAL (main.go:86) - failed to create network tracer: failed to init module: error guessing offsets: invalid guessing state while guessing destination address IPv6, got checking expected checked
```