### PR TITLE
[proc] put containers and processes running in containers in the same chunk

### DIFF
--- a/checks/container.go
+++ b/checks/container.go
@@ -58,7 +58,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	}
 
 	groupSize := len(ctrList) / cfg.MaxPerMessage
-	if len(ctrList) != cfg.MaxPerMessage {
+	if cfg.MaxPerMessage*groupSize != cfg.MaxPerMessage {
 		groupSize++
 	}
 	chunked := chunkContainers(ctrList, c.lastRates, c.lastRun, groupSize)
@@ -83,6 +83,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	return messages, nil
 }
 
+// fmtContainers loops through container list and converts them to a list of container objects
 func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time) []*model.Container {
 	containers := make([]*model.Container, 0, len(ctrList))
 	for _, ctr := range ctrList {
@@ -133,8 +134,8 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 	return containers
 }
 
-// chunkContainers formats and chunks the ctrList into a slice of chunks using a specific
-// number of chunks. len(result) MUST EQUAL chunks.
+// chunkContainers formats and chunks the ctrList into a slice of chunks using a specific number of chunks.
+// len(result) MUST EQUAL chunks.
 func chunkContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time, chunks int) [][]*model.Container {
 	perChunk := (len(ctrList) / chunks) + 1
 	chunked := make([][]*model.Container, chunks)

--- a/checks/container_nolinux.go
+++ b/checks/container_nolinux.go
@@ -44,11 +44,10 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 
 // chunkContainers formats and chunks the containers into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
-func chunkContainers(
-	ctrList []*containers.Container,
-	lastRates map[string]util.ContainerRateMetrics,
-	lastRun time.Time,
-	chunks int,
-) [][]*model.Container {
+func chunkContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time, chunks int) [][]*model.Container {
 	return make([][]*model.Container, chunks)
+}
+
+func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time) []*model.Container {
+	return make([]*model.Container, 0)
 }

--- a/checks/container_nolinux.go
+++ b/checks/container_nolinux.go
@@ -42,9 +42,9 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	return nil, nil
 }
 
-// fmtContainers formats and chunks the containers into a slice of chunks using a specific
+// chunkContainers formats and chunks the containers into a slice of chunks using a specific
 // number of chunks. len(result) MUST EQUAL chunks.
-func fmtContainers(
+func chunkContainers(
 	ctrList []*containers.Container,
 	lastRates map[string]util.ContainerRateMetrics,
 	lastRun time.Time,

--- a/checks/container_test.go
+++ b/checks/container_test.go
@@ -53,7 +53,7 @@ func TestContainerChunking(t *testing.T) {
 			expected: 2,
 		},
 	} {
-		chunked := fmtContainers(tc.cur, tc.last, lastRun, tc.chunks)
+		chunked := chunkContainers(tc.cur, tc.last, lastRun, tc.chunks)
 		assert.Len(t, chunked, tc.chunks, "len test %d", i)
 		total := 0
 		for _, c := range chunked {
@@ -76,7 +76,7 @@ func TestContainerNils(t *testing.T) {
 	// Make sure formatting doesn't crash with nils
 	cur := []*containers.Container{&containers.Container{}}
 	last := map[string]util.ContainerRateMetrics{}
-	fmtContainers(cur, last, time.Now(), 10)
+	chunkContainers(cur, last, time.Now(), 10)
 	fmtContainerStats(cur, last, time.Now(), 10)
 	// Make sure we get values when we have nils in last.
 	cur = []*containers.Container{
@@ -90,7 +90,7 @@ func TestContainerNils(t *testing.T) {
 			CPU: &metrics.CgroupTimesStat{},
 		},
 	}
-	fmtContainers(cur, last, time.Now(), 10)
+	chunkContainers(cur, last, time.Now(), 10)
 	fmtContainerStats(cur, last, time.Now(), 10)
 }
 

--- a/checks/process.go
+++ b/checks/process.go
@@ -17,6 +17,7 @@ import (
 
 // Process is a singleton ProcessCheck.
 var Process = &ProcessCheck{}
+var emptyCtrID = ""
 
 // ProcessCheck collects full state, including cmdline args and related metadata,
 // for live and running processes. The instance will store some state between
@@ -109,10 +110,10 @@ func createProcCtrMessages(
 	msgs := make([]*model.CollectorProc, 0)
 
 	// we first split non-container processes in chunks
-	if procsByCtr[""] != nil {
-		totalProcs += len(procsByCtr[""])
+	if procsByCtr[emptyCtrID] != nil {
+		totalProcs += len(procsByCtr[emptyCtrID])
 	}
-	chunks := chunkProcesses(procsByCtr[""], cfg.MaxPerMessage)
+	chunks := chunkProcesses(procsByCtr[emptyCtrID], cfg.MaxPerMessage)
 	for _, c := range chunks {
 		msgs = append(msgs, &model.CollectorProc{
 			HostName:  cfg.HostName,

--- a/checks/process.go
+++ b/checks/process.go
@@ -158,7 +158,7 @@ func chunkProcesses(procs []*model.Process, size int) [][]*model.Process {
 	return chunks
 }
 
-// fmtProcesses goes through each process, converts them to process object and group them by containers
+// fmtProcesses goes through each process, converts them to Process objects and group them by containers
 // non-container processes would be in a single group with key as empty string ""
 func fmtProcesses(
 	cfg *config.AgentConfig,

--- a/checks/process.go
+++ b/checks/process.go
@@ -158,7 +158,7 @@ func chunkProcesses(procs []*model.Process, size int) [][]*model.Process {
 	return chunks
 }
 
-// fmtProcesses goes through each process, converts them to Process objects and group them by containers
+// fmtProcesses goes through each process, converts them to process object and group them by containers
 // non-container processes would be in a single group with key as empty string ""
 func fmtProcesses(
 	cfg *config.AgentConfig,

--- a/checks/process_test.go
+++ b/checks/process_test.go
@@ -113,7 +113,7 @@ func TestProcessMessages(t *testing.T) {
 			totalProcs:      3,
 			totalContainers: 2,
 		},
-		// this tests the case that all processes in a container is skipped, container shouldn't be stored
+		// this tests the case that all processes in a container are skipped, container shouldn't be stored
 		{
 			cur:             map[int32]*process.FilledProcess{p[0].Pid: p[0], p[1].Pid: p[1], p[2].Pid: p[2]},
 			last:            map[int32]*process.FilledProcess{p[0].Pid: p[0], p[1].Pid: p[1], p[2].Pid: p[2]},
@@ -212,7 +212,7 @@ func TestProcessChunking(t *testing.T) {
 
 		procs := fmtProcesses(cfg, cur, last, containers, syst2, syst1, lastRun)
 		// only deal with non-container processes
-		chunked := chunkProcesses(procs[""], cfg.MaxPerMessage)
+		chunked := chunkProcesses(procs[emptyCtrID], cfg.MaxPerMessage)
 		assert.Len(t, chunked, tc.expectedChunks, "len %d", i)
 		total := 0
 		for _, c := range chunked {

--- a/checks/process_test.go
+++ b/checks/process_test.go
@@ -33,6 +33,7 @@ func TestProcessChunking(t *testing.T) {
 		makeProcess(3, "datadog-process-agent -ddconfig datadog.conf"),
 		makeProcess(4, "foo -bar -bim"),
 	}
+	containers := []*containers.Container{}
 	lastRun := time.Now().Add(-5 * time.Second)
 	syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
 	cfg := config.NewDefaultAgentConfig()
@@ -43,7 +44,6 @@ func TestProcessChunking(t *testing.T) {
 		blacklist      []string
 		expectedTotal  int
 		expectedChunks int
-		containers     []*containers.Container
 	}{
 		{
 			cur:            []*process.FilledProcess{p[0], p[1], p[2]},
@@ -52,7 +52,6 @@ func TestProcessChunking(t *testing.T) {
 			blacklist:      []string{},
 			expectedTotal:  3,
 			expectedChunks: 3,
-			containers:     []*containers.Container{},
 		},
 		{
 			cur:            []*process.FilledProcess{p[0], p[1], p[2]},
@@ -61,7 +60,6 @@ func TestProcessChunking(t *testing.T) {
 			blacklist:      []string{},
 			expectedTotal:  2,
 			expectedChunks: 2,
-			containers:     []*containers.Container{},
 		},
 		{
 			cur:            []*process.FilledProcess{p[0], p[1], p[2], p[3]},
@@ -70,7 +68,6 @@ func TestProcessChunking(t *testing.T) {
 			blacklist:      []string{"git", "datadog"},
 			expectedTotal:  2,
 			expectedChunks: 1,
-			containers:     []*containers.Container{},
 		},
 		{
 			cur:            []*process.FilledProcess{p[0], p[1], p[2], p[3]},
@@ -79,7 +76,6 @@ func TestProcessChunking(t *testing.T) {
 			blacklist:      []string{"git", "datadog", "foo", "mine"},
 			expectedTotal:  0,
 			expectedChunks: 0,
-			containers:     []*containers.Container{},
 		},
 	} {
 		bl := make([]*regexp.Regexp, 0, len(tc.blacklist))
@@ -98,7 +94,7 @@ func TestProcessChunking(t *testing.T) {
 			last[c.Pid] = c
 		}
 
-		procs := fmtProcesses(cfg, cur, last, tc.containers, syst2, syst1, lastRun)
+		procs := fmtProcesses(cfg, cur, last, containers, syst2, syst1, lastRun)
 		// only deal with non-container processes
 		chunked := chunkProcesses(procs[""], cfg.MaxPerMessage)
 		assert.Len(t, chunked, tc.expectedChunks, "len %d", i)
@@ -108,7 +104,7 @@ func TestProcessChunking(t *testing.T) {
 		}
 		assert.Equal(t, tc.expectedTotal, total, "total test %d", i)
 
-		chunkedStat := fmtProcessStats(cfg, cur, last, tc.containers, syst2, syst1, lastRun)
+		chunkedStat := fmtProcessStats(cfg, cur, last, containers, syst2, syst1, lastRun)
 		assert.Len(t, chunkedStat, tc.expectedChunks, "len stat %d", i)
 		total = 0
 		for _, c := range chunkedStat {

--- a/checks/process_test.go
+++ b/checks/process_test.go
@@ -1,12 +1,13 @@
 package checks
 
 import (
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/gopsutil/cpu"
@@ -93,7 +94,9 @@ func TestProcessChunking(t *testing.T) {
 			last[c.Pid] = c
 		}
 
-		chunked := fmtProcesses(cfg, cur, last, containers, syst2, syst1, lastRun)
+		procs := fmtProcesses(cfg, cur, last, containers, syst2, syst1, lastRun)
+		// only deal with non-container processes
+		chunked := chunkProcesses(procs[""], cfg.MaxPerMessage)
 		assert.Len(t, chunked, tc.expectedChunks, "len %d", i)
 		total := 0
 		for _, c := range chunked {


### PR DESCRIPTION
To: @DataDog/burrito 

When we split big payloads into smaller chunks, there was a bug that processes for some containers ended up in a different chunk, this results in that when we tried to attach container tags to processes, sometimes the lookup failed so the container tags are missing from those processes.

This PR tries to gather all processes running in containers together with the containers in a single message, while splitting non-container processes into chunks of messages. 

Previously `fmtProcesses` and `fmtContainers` create process/container objects and also splitting them evenly, in this version they only return a list of objects, then pass them along to `chunkProcesses` and `chunkContainers` for splitting.

The change is everywhere and I have next to no confidence that this would work, please review with all your strength. 