### PR TITLE
Fix CI fails due to retrieving goautoneg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  branch = "default"
   digest = "1:db5c4e7a9516334fb1e9d5951fb9943d0f13e4f415a77c22b97e60f4d10a62a7"
   name = "bitbucket.org/ww/goautoneg"
   packages = ["."]
   pruneopts = ""
-  revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+  revision = "d788f35a0315672bc90f50a6145d1252a230ee0d"
+  source = "github.com/adjust/goautoneg"
 
 [[projects]]
   digest = "1:e614c1c911617d660f569202b4680239069793b7ca473a8c3e644240551b12b0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,3 +27,8 @@
 [[override]]
   name = "github.com/kardianos/osext"
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
+
+[[override]]
+  name = "bitbucket.org/ww/goautoneg"
+  source = "github.com/adjust/goautoneg"
+  revision = "d788f35a0315672bc90f50a6145d1252a230ee0d"


### PR DESCRIPTION
Related: https://github.com/DataDog/datadog-agent/pull/2738/files

https://circleci.com/gh/DataDog/datadog-process-agent/997:
```
grouped write of manifest, lock and vendor: error while writing out vendor tree: failed to write dep tree: failed to export bitbucket.org/ww/goautoneg: 
	(1) source does not exist upstream: hg: https://bitbucket.org/ww/goautoneg
	(2) source does not exist upstream: hg: ssh://hg@bitbucket.org/ww/goautoneg
	(3) source does not exist upstream: hg: http://bitbucket.org/ww/goautoneg
	(4) failed to list versions for https://bitbucket.org/ww/goautoneg: remote: Mercurial (hg) is required to use this repository.
remote: 
remote: https://confluence.atlassian.com/x/vLRCMw
fatal: unable to access 'https://bitbucket.org/ww/goautoneg/': The requested URL returned error: 405
: exit status 128
	(5) failed to list versions for ssh://git@bitbucket.org/ww/goautoneg: Permission denied (publickey).

fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
: exit status 128
	(6) failed to list versions for git://bitbucket.org/ww/goautoneg: fatal: unable to connect to bitbucket.org:
bitbucket.org[0: 18.205.93.0]: errno=Connection timed out
bitbucket.org[1: 18.205.93.2]: errno=Connection timed out
bitbucket.org[2: 18.205.93.1]: errno=Connection timed out
bitbucket.org[3: 2406:da00:ff00::22e9:9f55]: errno=Network is unreachable
bitbucket.org[4: 2406:da00:ff00::22c2:513]: errno=Network is unreachable
bitbucket.org[5: 2406:da00:ff00::3403:4be7]: errno=Network is unreachable

: exit status 128
	(7) failed to list versions for http://bitbucket.org/ww/goautoneg: remote: Mercurial (hg) is required to use this repository.
remote: 
remote: https://confluence.atlassian.com/x/vLRCMw
fatal: unable to access 'http://bitbucket.org/ww/goautoneg/': The requested URL returned error: 405
: exit status 128```