### PR TITLE
Skip process info query for pid 0

### DIFF
--- a/checks/allprocesses_windows.go
+++ b/checks/allprocesses_windows.go
@@ -356,6 +356,10 @@ func rebuildProcessMapFromWMI() {
 	}
 
 	for pid, proc := range wmimap {
+		if pid == 0 {
+			// PID 0 is System Process, will cause syscall.OpenProcess to fail with ERROR_INVALID_PARAMETER.
+			continue
+		}
 		cp := cachedProcess{}
 		if err := cp.fill(&proc); err != nil {
 			continue


### PR DESCRIPTION
Windows process agent is very noisy with this specific log line.
![image](https://user-images.githubusercontent.com/9057843/49760133-a005eb00-fc91-11e8-96f3-a40c935363c0.png)
process agent constantly updates process information. It will query for PID 0 System Idle Process which cannot be queried.
https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-openprocess
`If the specified process is the System Process (0x00000000), the function fails and the last error code is ERROR_INVALID_PARAMETER. `
Which is the same error log we see. 

https://stackoverflow.com/questions/3232401/windows-pid-0-valid
