### PR TITLE
Explicitly enabling process checks should not disable container checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -267,7 +267,7 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig, networkYaml *Yam
 		v, _ := agentIni.Get("Main", "process_agent_enabled")
 		if enabled, err := isAffirmative(v); enabled {
 			cfg.Enabled = true
-			cfg.EnabledChecks = processChecks
+			cfg.EnabledChecks = append(cfg.EnabledChecks, processChecks...)
 		} else if !enabled && err == nil { // Only want to disable the process agent if it's explicitly disabled
 			cfg.Enabled = false
 		}
@@ -442,7 +442,7 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 	var err error
 	if enabled, err := isAffirmative(os.Getenv("DD_PROCESS_AGENT_ENABLED")); enabled {
 		c.Enabled = true
-		c.EnabledChecks = processChecks
+		c.EnabledChecks = append(c.EnabledChecks, processChecks...)
 	} else if !enabled && err == nil {
 		c.Enabled = false
 	}

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -119,12 +119,12 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 
 	if enabled, err := isAffirmative(yc.Process.Enabled); enabled {
 		agentConf.Enabled = true
-		agentConf.EnabledChecks = processChecks
+		agentConf.EnabledChecks = append(agentConf.EnabledChecks, processChecks...)
 	} else if strings.ToLower(yc.Process.Enabled) == "disabled" {
 		agentConf.Enabled = false
 	} else if !enabled && err == nil {
 		agentConf.Enabled = true
-		agentConf.EnabledChecks = containerChecks
+		agentConf.EnabledChecks = append(agentConf.EnabledChecks, containerChecks...)
 	}
 	url, err := url.Parse(ddconfig.GetMainEndpoint("https://process.", "process_config.process_dd_url"))
 	if err != nil {


### PR DESCRIPTION
The yaml configuration parsing for the process-agent makes it impossible to collect both container and process metrics. To reproduce:

- create a file test.yaml:
- build and run process-agent `.rake build && ./process-agent ./config test.yaml`
- the logs include the line

> 2018-12-14 14:29:46 INFO (collector.go:104) - Starting process-agent for host=vagrant, endpoints=[http://foo.bar], **enabled checks=[process rtprocess]**

According to our docs, this configuration should enable both contain and process checks.

