### PR TITLE
Rename process-checks to reflect that the process check gathers container information

### DIFF
--- a/checks/container_rt.go
+++ b/checks/container_rt.go
@@ -29,7 +29,7 @@ func (r *RTContainerCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 }
 
 // Name returns the name of the RTContainerCheck.
-func (r *RTContainerCheck) Name() string { return "rtcontainer" }
+func (r *RTContainerCheck) Name() string { return "rt-container" }
 
 // Endpoint returns the endpoint where this check is submitted.
 func (r *RTContainerCheck) Endpoint() string { return "/api/v1/container" }

--- a/checks/container_rt_nolinux.go
+++ b/checks/container_rt_nolinux.go
@@ -27,7 +27,7 @@ func (r *RTContainerCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 }
 
 // Name returns the name of the RTContainerCheck.
-func (r *RTContainerCheck) Name() string { return "rtcontainer" }
+func (r *RTContainerCheck) Name() string { return "rt-container" }
 
 // Endpoint returns the endpoint where this check is submitted.
 func (r *RTContainerCheck) Endpoint() string { return "/api/v1/container" }

--- a/checks/process.go
+++ b/checks/process.go
@@ -39,7 +39,7 @@ func (p *ProcessCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 }
 
 // Name returns the name of the ProcessCheck.
-func (p *ProcessCheck) Name() string { return "process" }
+func (p *ProcessCheck) Name() string { return "process-container" }
 
 // Endpoint returns the endpoint where this check is submitted.
 func (p *ProcessCheck) Endpoint() string { return "/api/v1/collector" }

--- a/checks/process_rt.go
+++ b/checks/process_rt.go
@@ -31,7 +31,7 @@ func (r *RTProcessCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 }
 
 // Name returns the name of the RTProcessCheck.
-func (r *RTProcessCheck) Name() string { return "rtprocess" }
+func (r *RTProcessCheck) Name() string { return "rt-process-container" }
 
 // Endpoint returns the endpoint where this check is submitted.
 func (r *RTProcessCheck) Endpoint() string { return "/api/v1/collector" }

--- a/config/config.go
+++ b/config/config.go
@@ -32,8 +32,8 @@ var (
 	// defaultNetworkLogFilePath is the default logging file for the network tracer
 	defaultNetworkLogFilePath = "/var/log/datadog/network-tracer.log"
 
-	processChecks   = []string{"process", "rtprocess"}
-	containerChecks = []string{"container", "rtcontainer"}
+	processChecks   = []string{"process-container", "rt-process-container"}
+	containerChecks = []string{"container", "rt-container"}
 
 	// List of known Kubernetes images that we want to exclude by default.
 	defaultKubeBlacklist = []string{
@@ -188,11 +188,11 @@ func NewDefaultAgentConfig() *AgentConfig {
 		// Check config
 		EnabledChecks: containerChecks,
 		CheckIntervals: map[string]time.Duration{
-			"process":     10 * time.Second,
-			"rtprocess":   2 * time.Second,
-			"container":   10 * time.Second,
-			"rtcontainer": 2 * time.Second,
-			"connections": 10 * time.Second,
+			"process-container":    10 * time.Second,
+			"rt-process":           2 * time.Second,
+			"container":            10 * time.Second,
+			"rt-process-container": 2 * time.Second,
+			"connections":          10 * time.Second,
 		},
 
 		// Docker

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -143,15 +143,15 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 	}
 	if yc.Process.Intervals.ContainerRealTime != 0 {
 		log.Infof("Overriding real-time container check interval to %ds", yc.Process.Intervals.ContainerRealTime)
-		agentConf.CheckIntervals["rtcontainer"] = time.Duration(yc.Process.Intervals.ContainerRealTime) * time.Second
+		agentConf.CheckIntervals["rt-container"] = time.Duration(yc.Process.Intervals.ContainerRealTime) * time.Second
 	}
 	if yc.Process.Intervals.Process != 0 {
 		log.Infof("Overriding process check interval to %ds", yc.Process.Intervals.Process)
-		agentConf.CheckIntervals["process"] = time.Duration(yc.Process.Intervals.Process) * time.Second
+		agentConf.CheckIntervals["process-container"] = time.Duration(yc.Process.Intervals.Process) * time.Second
 	}
 	if yc.Process.Intervals.ProcessRealTime != 0 {
 		log.Infof("Overriding real-time process check interval to %ds", yc.Process.Intervals.ProcessRealTime)
-		agentConf.CheckIntervals["rtprocess"] = time.Duration(yc.Process.Intervals.Process) * time.Second
+		agentConf.CheckIntervals["rt-process-container"] = time.Duration(yc.Process.Intervals.Process) * time.Second
 	}
 	if yc.Process.Intervals.Connections != 0 {
 		log.Infof("Overriding connections check interval to %ds", yc.Process.Intervals.Connections)


### PR DESCRIPTION
Changes the names of our checks to reflect that the process check also gathers container information. Hopefully this will save other from making the mistake I made in #229 