### PR TITLE
release file handles when rebuilding process map

### DIFF
--- a/checks/allprocesses_windows.go
+++ b/checks/allprocesses_windows.go
@@ -348,6 +348,9 @@ func parseCmdLineArgs(cmdline string) (res []string) {
 }
 
 func rebuildProcessMapFromWMI() {
+	for _, p := range cachedProcesses {
+		p.close()
+	}
 	cachedProcesses = make(map[uint32]cachedProcess)
 	wmimap, err := getProcessMapFromWMI()
 	if err != nil {


### PR DESCRIPTION
This fixes a bug where calling rebuildProcessMapFromWMI would delete go objects which referenced open file handles without releasing the handles. 

This behavior can be observed using windows performance toolkit following the instructions at http://geekswithblogs.net/akraus1/archive/2016/03/14/173308.aspx

To test, I started profiling and ran a batch script that spawned     notepad 100 times with a sleep in between and then killed all the notepad processes.

Results before:

<img width="1145" alt="process_agent_bad" src="https://user-images.githubusercontent.com/1482532/50654908-71abc080-0f5c-11e9-98f5-3d6e481b4dae.png">

And after

![agent_with_fix](https://user-images.githubusercontent.com/1482532/50654978-a4ee4f80-0f5c-11e9-8fbe-4acf52c4b485.png)
