### PR TITLE
Use new tagger interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
   version = "4.8"
 
 [[projects]]
-  digest = "1:b04daae0e01a9e5f3fb4c605ce9ed3bb1679fadd2bf8e84a7b9b6e0357a6f7ed"
+  digest = "1:d0724fd3ad246a588b45b31d16da06d93a3aa91f01d5f43027fe818a435c37d7"
   name = "github.com/DataDog/datadog-agent"
   packages = [
     "cmd/agent/api/response",
@@ -62,7 +62,7 @@
     "pkg/version",
   ]
   pruneopts = ""
-  revision = "a5dbafed6d1550f1e43b79cc0c8b28718693f325"
+  revision = "d7b476d9424edcdcec13d69148a3230eae771def"
 
 [[projects]]
   digest = "1:7a91a175c283b21c6e99edc1b2fb82fe11eb5b42e7a28a2a67b17d9c28ad1855"
@@ -986,6 +986,7 @@
     "github.com/DataDog/datadog-agent/pkg/config",
     "github.com/DataDog/datadog-agent/pkg/pidfile",
     "github.com/DataDog/datadog-agent/pkg/tagger",
+    "github.com/DataDog/datadog-agent/pkg/tagger/collectors",
     "github.com/DataDog/datadog-agent/pkg/util",
     "github.com/DataDog/datadog-agent/pkg/util/cache",
     "github.com/DataDog/datadog-agent/pkg/util/containers",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/DataDog/datadog-agent"
-  revision = "a5dbafed6d1550f1e43b79cc0c8b28718693f325"
+  revision = "d7b476d9424edcdcec13d69148a3230eae771def"
 
 [[constraint]]
   name = "github.com/DataDog/gopsutil"

--- a/checks/container.go
+++ b/checks/container.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	log "github.com/cihub/seelog"
 
@@ -102,7 +103,7 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
 		// Retrieves metadata tags
-		tags, err := tagger.Tag(ctr.EntityID, true)
+		tags, err := tagger.Tag(ctr.EntityID, collectors.HighCardinality)
 		if err != nil {
 			log.Errorf("unable to retrieve tags for container: %s", err)
 			tags = []string{}


### PR DESCRIPTION
`tagger.Tag` now asks for a `TagCardinality` instead of `highCard bool`, update the process-agent code to use that.