### PR TITLE
[network-tracer] Fix C.uint -> uint type casting for go version prior to 1.11 and update Dockerfile-nettop go version to 1.11.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -191,20 +191,7 @@ namespace "ebpf" do
   end
 
   desc "Generate and instal eBPF program via gobindata"
-  task :build => ['ebpf:fmt', 'ebpf:image'] do
-    cmd = "build"
-    if ENV['TEST'] != "true"
-      cmd += " install"
-    end
-    sh "#{sudo} docker run --rm -e DEBUG=#{DEBUG} \
-        -e CIRCLE_BUILD_URL=#{ENV['CIRCLE_BUILD_URL']} \
-        -v $(pwd):/src:ro \
-    -v $(pwd)/ebpf:/ebpf/ \
-        --workdir=/src \
-        #{DOCKER_IMAGE} \
-        make -f ebpf/c/tracer-ebpf.mk #{cmd}"
-    sh "sudo chown -R $(id -u):$(id -u) ebpf"
-  end
+  task :build => ['ebpf:fmt', 'ebpf:image', 'ebpf:build-only']
 
   desc "Build only the eBPF object (do not rebuild the docker image builder)"
   task 'build-only' do
@@ -222,14 +209,14 @@ namespace "ebpf" do
     sh "sudo chown -R $(id -u):$(id -u) ebpf"
   end
 
-    desc "Build and run dockerized `nettop` command for testing"
-    task :nettop => 'ebpf:build' do
-      sh 'sudo docker build -t "ebpf-nettop" . -f packaging/Dockerfile-nettop'
-      sh "sudo docker run \
-        --net=host \
-        --cap-add=SYS_ADMIN \
-        --privileged \
-        -v /sys/kernel/debug:/sys/kernel/debug \
-        ebpf-nettop"
-    end
+  desc "Build and run dockerized `nettop` command for testing"
+  task :nettop => 'ebpf:build' do
+    sh 'sudo docker build -t "ebpf-nettop" . -f packaging/Dockerfile-nettop'
+    sh "sudo docker run \
+      --net=host \
+      --cap-add=SYS_ADMIN \
+      --privileged \
+      -v /sys/kernel/debug:/sys/kernel/debug \
+      ebpf-nettop"
+  end
 end

--- a/ebpf/event.go
+++ b/ebpf/event.go
@@ -56,10 +56,10 @@ func (cs *ConnStatsWithTimestamp) isExpired(latestTime int64, timeout int64) boo
 }
 
 func connStats(t *ConnTuple, s *ConnStatsWithTimestamp, tcpStats *TCPStats) ConnectionStats {
-	family := connFamily(t.metadata)
+	family := connFamily(uint(t.metadata))
 	return ConnectionStats{
 		Pid:         uint32(t.pid),
-		Type:        connType(t.metadata),
+		Type:        connType(uint(t.metadata)),
 		Family:      family,
 		Source:      ipString(uint64(t.saddr_h), uint64(t.saddr_l), family),
 		Dest:        ipString(uint64(t.daddr_h), uint64(t.daddr_l), family),
@@ -84,7 +84,7 @@ func ipString(addr_h, addr_l uint64, family ConnectionFamily) string {
 	return net.IP(buf).String()
 }
 
-func connType(m _Ctype_uint) ConnectionType {
+func connType(m uint) ConnectionType {
 	// First bit of metadata indicates if the connection is TCP or UDP
 	if m&C.CONN_TYPE_TCP == 0 {
 		return UDP
@@ -92,7 +92,7 @@ func connType(m _Ctype_uint) ConnectionType {
 	return TCP
 }
 
-func connFamily(m _Ctype_uint) ConnectionFamily {
+func connFamily(m uint) ConnectionFamily {
 	// Second bit of metadata indicates if the connection is IPv6 or IPv4
 	if m&C.CONN_V6 == 0 {
 		return AFINET

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -204,7 +204,7 @@ func loadBPFModule() (*bpflib.Module, error) {
 }
 
 func (t *Tracer) timeoutForConn(c *ConnTuple) int64 {
-	if connType(c.metadata) == TCP {
+	if connType(uint(c.metadata)) == TCP {
 		return t.config.TCPConnTimeout.Nanoseconds()
 	}
 	return t.config.UDPConnTimeout.Nanoseconds()

--- a/packaging/Dockerfile-nettop
+++ b/packaging/Dockerfile-nettop
@@ -5,7 +5,7 @@ RUN dnf update -y && \
       openssl-devel libcap-devel clang llvm kernel-devel && \
     dnf clean all
 
-ENV GOLANG_VERSION 1.9.1
+ENV GOLANG_VERSION 1.11.2
 ENV GOPATH /go
 ENV GOROOT /root/.gvm/versions/go${GOLANG_VERSION}.linux.amd64
 


### PR DESCRIPTION
When trying to build nettop on go 1.9.1:

We get:
```
../../ebpf/event.go:59: cannot use t.metadata (type C.__u32) as type C.uint in argument to connFamily
../../ebpf/event.go:62: cannot use t.metadata (type C.__u32) as type C.uint in argument to connType
../../ebpf/tracer.go:207: cannot use c.metadata (type C.__u32) as type C.uint in argument to connType
```