### PR TITLE
Increase connections batch size from 100 to 300

### DIFF
--- a/checks/net.go
+++ b/checks/net.go
@@ -200,11 +200,11 @@ func formatType(f ebpf.ConnectionType) model.ConnectionType {
 }
 
 func batchConnections(cfg *config.AgentConfig, groupID int32, cxs []*model.Connection) []model.MessageBody {
-	groupSize := groupSize(len(cxs), cfg.MaxPerMessage)
+	groupSize := groupSize(len(cxs), cfg.MaxConnsPerMessage)
 	batches := make([]model.MessageBody, 0, groupSize)
 
 	for len(cxs) > 0 {
-		batchSize := min(cfg.MaxPerMessage, len(cxs))
+		batchSize := min(cfg.MaxConnsPerMessage, len(cxs))
 		batches = append(batches, &model.CollectorConnections{
 			HostName:    cfg.HostName,
 			Connections: cxs[:batchSize],

--- a/checks/net_test.go
+++ b/checks/net_test.go
@@ -59,7 +59,7 @@ func TestNetworkConnectionBatching(t *testing.T) {
 			expectedChunks: 3,
 		},
 	} {
-		cfg.MaxPerMessage = tc.maxSize
+		cfg.MaxConnsPerMessage = tc.maxSize
 		chunks := batchConnections(cfg, 0, tc.cur)
 
 		assert.Len(t, chunks, tc.expectedChunks, "len %d", i)

--- a/config/config.go
+++ b/config/config.go
@@ -61,25 +61,26 @@ type APIEndpoint struct {
 // AgentConfig is the global config for the process-agent. This information
 // is sourced from config files and the environment variables.
 type AgentConfig struct {
-	Enabled       bool
-	HostName      string
-	APIEndpoints  []APIEndpoint
-	LogFile       string
-	LogLevel      string
-	LogToConsole  bool
-	QueueSize     int
-	Blacklist     []*regexp.Regexp
-	Scrubber      *DataScrubber
-	MaxProcFDs    int
-	MaxPerMessage int
-	AllowRealTime bool
-	Transport     *http.Transport `json:"-"`
-	Logger        *LoggerConfig
-	DDAgentPy     string
-	DDAgentBin    string
-	DDAgentPyEnv  []string
-	StatsdHost    string
-	StatsdPort    int
+	Enabled            bool
+	HostName           string
+	APIEndpoints       []APIEndpoint
+	LogFile            string
+	LogLevel           string
+	LogToConsole       bool
+	QueueSize          int
+	Blacklist          []*regexp.Regexp
+	Scrubber           *DataScrubber
+	MaxProcFDs         int
+	MaxPerMessage      int
+	MaxConnsPerMessage int
+	AllowRealTime      bool
+	Transport          *http.Transport `json:"-"`
+	Logger             *LoggerConfig
+	DDAgentPy          string
+	DDAgentBin         string
+	DDAgentPyEnv       []string
+	StatsdHost         string
+	StatsdPort         int
 
 	// Network collection configuration
 	EnableNetworkTracing     bool
@@ -123,8 +124,9 @@ func (a AgentConfig) CheckInterval(checkName string) time.Duration {
 }
 
 const (
-	defaultEndpoint = "https://process.datadoghq.com"
-	maxMessageBatch = 100
+	defaultEndpoint      = "https://process.datadoghq.com"
+	maxMessageBatch      = 100
+	maxConnsMessageBatch = 300
 )
 
 // NewDefaultTransport provides a http transport configuration with sane default timeouts
@@ -156,17 +158,18 @@ func NewDefaultAgentConfig() *AgentConfig {
 	canAccessContainers := err == nil
 
 	ac := &AgentConfig{
-		Enabled:       canAccessContainers, // We'll always run inside of a container.
-		APIEndpoints:  []APIEndpoint{{Endpoint: u}},
-		LogFile:       defaultLogFilePath,
-		LogLevel:      "info",
-		LogToConsole:  false,
-		QueueSize:     20,
-		MaxProcFDs:    200,
-		MaxPerMessage: 100,
-		AllowRealTime: true,
-		HostName:      "",
-		Transport:     NewDefaultTransport(),
+		Enabled:            canAccessContainers, // We'll always run inside of a container.
+		APIEndpoints:       []APIEndpoint{{Endpoint: u}},
+		LogFile:            defaultLogFilePath,
+		LogLevel:           "info",
+		LogToConsole:       false,
+		QueueSize:          20,
+		MaxProcFDs:         200,
+		MaxPerMessage:      100,
+		MaxConnsPerMessage: 300,
+		AllowRealTime:      true,
+		HostName:           "",
+		Transport:          NewDefaultTransport(),
 
 		// Statsd for internal instrumentation
 		StatsdHost: "127.0.0.1",


### PR DESCRIPTION
We were previously using the same batch size as for processes/containers but network connections are more lightweight so we can send more connections per batch, according to our intake stats a network message is 3 to 4 times smaller than a process message, hence the increase from 100 to 300, there also is a struct comparison for both messages here: https://gist.github.com/sfluor/a7e1dca57891f020ad4c35c8a603e2c2

A process message size is ~ 5Kb
A connections message size is currently ~ 1.4Kb, with the increase it should be 4.2 Kb
