### PR TITLE
[fix] default max tracked connections value

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -189,6 +189,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		DisableIPv6Tracing:       false,
 		NetworkTracerSocketPath:  defaultNetworkTracerSocketPath,
 		NetworkTracerLogFile:     defaultNetworkLogFilePath,
+		MaxTrackedConnections:    maxMaxTrackedConnections,
 
 		// Check config
 		EnabledChecks: containerChecks,


### PR DESCRIPTION
default max tracked connections value was set to 0 in the agent config and to 65536 in the network config, but we override the network config with the agent config

This resulted in the following errors:
`failed to create network tracer: error while loading map "maps/conn_stats": invalid argument`