### PR TITLE
Improving memory usage of network-tracer's state management

### DIFF
--- a/cmd/network-tracer/tracer.go
+++ b/cmd/network-tracer/tracer.go
@@ -13,6 +13,8 @@ import (
 	"github.com/DataDog/datadog-process-agent/config"
 	"github.com/DataDog/datadog-process-agent/ebpf"
 	"github.com/DataDog/datadog-process-agent/net"
+
+	_ "net/http/pprof"
 )
 
 // ErrTracerUnsupported is the unsupported error prefix, for error-class matching from callers
@@ -67,8 +69,7 @@ func (nt *NetworkTracer) Run() {
 		var clientID string
 		if rawCID := req.URL.Query().Get("client_id"); rawCID != "" {
 			clientID = rawCID
-		} else {
-			// This is the default client ID
+		} else { // This is the default client ID
 			clientID = ebpf.DEBUGCLIENT
 		}
 
@@ -87,7 +88,7 @@ func (nt *NetworkTracer) Run() {
 		}
 
 		w.Write(buf)
-		log.Debugf("/connections: %d connections, %d bytes", len(cs.Conns), len(buf))
+		log.Tracef("/connections: %d connections, %d bytes", len(cs.Conns), len(buf))
 	})
 
 	http.Serve(nt.conn.GetListener(), nil)

--- a/ebpf/event_common.go
+++ b/ebpf/event_common.go
@@ -119,8 +119,8 @@ func (c ConnectionStats) ByteKey(buffer *bytes.Buffer) ([]byte, error) {
 	if _, err := buffer.WriteString(c.Source); err != nil {
 		return nil, err
 	}
-	// Family (8 bits) + Type (8 bits) = 16 bits
-	p1 := uint16(c.Family)<<8 | uint16(c.Type)
+	// Family (4 bits) + Type (4 bits) = 8 bits
+	p1 := uint8(c.Family)<<4 | uint8(c.Type)
 	if err := binary.Write(buffer, binary.LittleEndian, p1); err != nil {
 		return nil, err
 	}

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -21,11 +21,20 @@ const (
 // - closed connections
 // - sent and received bytes per connection
 type NetworkState interface {
-	Connections(clientID string) []ConnectionStats // Returns the list of connections for the given client
-	StoreConnections(conns []ConnectionStats)      // Store new connections in state
-	StoreClosedConnection(conn ConnectionStats)    // Store a new closed connection
-	RemoveClient(clientID string)                  // Stop tracking stateful data for the given client
-	RemoveDuplicates(conns map[string]*ConnectionStats, closedConns []ConnectionStats) []ConnectionStats
+	// Connections returns the list of connections for the given client
+	Connections(clientID string) []ConnectionStats
+
+	// StoreConnections stores new active connections
+	StoreConnections(conns []ConnectionStats)
+
+	// StoreClosedConnection stores a new closed connection
+	StoreClosedConnection(conn ConnectionStats)
+
+	// RemoveClient stops tracking stateful data for a given client
+	RemoveClient(clientID string)
+
+	// RemoveDuplicates removes duplicate connections from active and closed sets of connections, preferring closed.
+	RemoveDuplicates(active map[string]*ConnectionStats, closed []ConnectionStats) []ConnectionStats
 }
 
 type sentRecvStats struct {

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -103,13 +103,13 @@ func (ns *networkState) getClients() []string {
 // If the client is not registered yet, we register it and return the connections we have in the global state
 // Otherwise we return both the connections with last stats and the closed connections for this client
 func (ns *networkState) Connections(id string) []ConnectionStats {
-	// First time we see this client, use global state
-	if old := ns.newClient(id); !old {
+	// If its the first time we've seen this client, use global state as connection set
+	if ok := ns.newClient(id); !ok {
 		ns.Lock()
 		defer ns.Unlock()
 		conns := make([]ConnectionStats, 0, len(ns.connections))
-		for _, conn := range ns.connections {
-			conns = append(conns, *conn)
+		for _, c := range ns.connections {
+			conns = append(conns, *c)
 		}
 		return conns
 	}

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -137,14 +137,14 @@ func (ns *networkState) StoreConnections(conns []ConnectionStats) {
 	// Flush the previous map
 	ns.connections = map[string]*ConnectionStats{}
 
-	for _, c := range conns {
+	for i, c := range conns {
 		key, err := c.ByteKey(ns.buf)
 		if err != nil {
 			log.Errorf("%s", err)
 			continue
 		}
 
-		ns.connections[string(key)] = &c
+		ns.connections[string(key)] = &conns[i]
 
 		// Check if some clients don't have the same connection still stored as closed
 		// if they do remove it from the closed connections and store in the override connections

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -137,7 +137,7 @@ func (ns *networkState) updateActiveConnections(conns []ConnectionStats) map[str
 	for i, c := range conns {
 		key, err := c.ByteKey(ns.buf)
 		if err != nil {
-			log.Errorf("%s", err)
+			log.Warn("failed to create byte key: %s", err)
 			continue
 		}
 
@@ -171,7 +171,7 @@ func (ns *networkState) StoreClosedConnection(conn ConnectionStats) {
 	now := time.Now()
 	key, err := conn.ByteKey(ns.buf)
 	if err != nil {
-		log.Errorf("%s", err)
+		log.Warn("failed to create byte key: %s", err)
 		return
 	}
 
@@ -298,7 +298,7 @@ func (ns *networkState) removeExpiredClients(now time.Time, removeExpiredStats b
 	}
 
 	if deletedStats > 0 {
-		log.Infof("removed %d expired stats objects in %d", deletedStats, time.Now().Sub(now))
+		log.Debugf("removed %d expired stats objects in %d", deletedStats, time.Now().Sub(now))
 	}
 }
 
@@ -379,7 +379,7 @@ func (ns *networkState) RemoveDuplicates(latest map[string]*ConnectionStats, clo
 	for _, c := range closed {
 		key, err := c.ByteKey(ns.buf)
 		if err != nil {
-			log.Errorf("%s", err)
+			log.Warn("failed to create byte key: %s", err)
 			continue
 		}
 

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -68,6 +68,57 @@ func TestRemoveDuplicates(t *testing.T) {
 	assert.Equal(t, 2, len(removeDuplicates(conns, closedConns)))
 }
 
+func BenchmarkRemoveDuplicates(b *testing.B) {
+	conn1 := ConnectionStats{
+		Pid:                  123,
+		Type:                 TCP,
+		Family:               AFINET,
+		Source:               "localhost",
+		Dest:                 "localhost",
+		SPort:                31890,
+		DPort:                80,
+		MonotonicSentBytes:   12345,
+		MonotonicRecvBytes:   6789,
+		MonotonicRetransmits: 2,
+	}
+
+	conn2 := ConnectionStats{
+		Pid:                  123,
+		Type:                 TCP,
+		Family:               AFINET6,
+		Source:               "localhost",
+		Dest:                 "localhost",
+		SPort:                31890,
+		DPort:                80,
+		MonotonicSentBytes:   12345,
+		MonotonicRecvBytes:   6789,
+		MonotonicRetransmits: 2,
+	}
+
+	conn3 := ConnectionStats{
+		Pid:                  123,
+		Type:                 TCP,
+		Family:               AFINET,
+		Source:               "localhost",
+		Dest:                 "localhost",
+		SPort:                31890,
+		DPort:                80,
+		MonotonicSentBytes:   0,
+		MonotonicRecvBytes:   123,
+		MonotonicRetransmits: 1,
+	}
+
+	conns := []ConnectionStats{conn3}
+	closedConns := []ConnectionStats{conn1, conn1, conn1, conn2, conn2, conn2, conn3, conn3, conn3}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		removeDuplicates(conns, closedConns)
+	}
+}
+
 func TestRetrieveClosedConnection(t *testing.T) {
 	conn := ConnectionStats{
 		Pid:                  123,

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -54,8 +54,8 @@ func TestRemoveDuplicates(t *testing.T) {
 		MonotonicRetransmits: 1,
 	}
 
-	conns := []ConnectionStats{conn1, conn1}
-	closedConns := []ConnectionStats{}
+	conns := []ConnectionStats{conn1}
+	closedConns := []ConnectionStats{conn1}
 	assert.Equal(t, 1, len(removeDuplicates(conns, closedConns)))
 
 	// conn1 and conn3 are duplicates
@@ -64,7 +64,8 @@ func TestRemoveDuplicates(t *testing.T) {
 	assert.Equal(t, 1, len(removeDuplicates(conns, closedConns)))
 	assert.Equal(t, conn3, removeDuplicates(conns, closedConns)[0])
 
-	conns = []ConnectionStats{conn1, conn1, conn1, conn2, conn2, conn2, conn3, conn3, conn3}
+	conns = []ConnectionStats{}
+	closedConns = []ConnectionStats{conn1, conn1, conn1, conn2, conn2, conn2, conn3, conn3, conn3}
 	assert.Equal(t, 2, len(removeDuplicates(conns, closedConns)))
 }
 

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -293,7 +293,7 @@ func TestCleanupClient(t *testing.T) {
 
 	wait := 100 * time.Millisecond
 
-	state := NewNetworkState(defaultCleanInterval, wait)
+	state := NewNetworkState(defaultClientInterval, wait)
 	clients := state.(*networkState).getClients()
 	assert.Equal(t, 0, len(clients))
 
@@ -301,7 +301,7 @@ func TestCleanupClient(t *testing.T) {
 	assert.Equal(t, 0, len(conns))
 
 	// Should be a no op
-	state.(*networkState).removeExpiredClients(time.Now())
+	state.(*networkState).removeExpiredClients(time.Now(), false)
 
 	clients = state.(*networkState).getClients()
 	assert.Equal(t, 1, len(clients))
@@ -310,7 +310,7 @@ func TestCleanupClient(t *testing.T) {
 	time.Sleep(wait)
 
 	// Should delete the client 1
-	state.(*networkState).removeExpiredClients(time.Now())
+	state.(*networkState).removeExpiredClients(time.Now(), false)
 
 	clients = state.(*networkState).getClients()
 	assert.Equal(t, 0, len(clients))

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -3,6 +3,7 @@
 package ebpf
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"math/rand"
@@ -56,18 +57,19 @@ func TestRemoveDuplicates(t *testing.T) {
 	}
 
 	ns := NewDefaultNetworkState()
+	k1, _ := conn1.ByteKey(&bytes.Buffer{})
 
-	conns := []ConnectionStats{conn1}
+	conns := map[string]*ConnectionStats{string(k1): &conn1}
 	closedConns := []ConnectionStats{conn1}
 	assert.Equal(t, 1, len(ns.RemoveDuplicates(conns, closedConns)))
 
 	// conn1 and conn3 are duplicates
-	conns = []ConnectionStats{conn1}
+	conns = map[string]*ConnectionStats{string(k1): &conn1}
 	closedConns = []ConnectionStats{conn3}
 	assert.Equal(t, 1, len(ns.RemoveDuplicates(conns, closedConns)))
 	assert.Equal(t, conn3, ns.RemoveDuplicates(conns, closedConns)[0])
 
-	conns = []ConnectionStats{}
+	conns = map[string]*ConnectionStats{}
 	closedConns = []ConnectionStats{conn1, conn1, conn1, conn2, conn2, conn2, conn3, conn3, conn3}
 	assert.Equal(t, 2, len(ns.RemoveDuplicates(conns, closedConns)))
 }
@@ -114,7 +116,8 @@ func BenchmarkRemoveDuplicates(b *testing.B) {
 		MonotonicRetransmits: 1,
 	}
 
-	conns := []ConnectionStats{conn3}
+	k1, _ := conn1.ByteKey(&bytes.Buffer{})
+	conns := map[string]*ConnectionStats{string(k1): &conn1}
 	closedConns := []ConnectionStats{conn1, conn1, conn1, conn2, conn2, conn2, conn3, conn3, conn3}
 
 	b.ResetTimer()

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -121,6 +121,7 @@ func BenchmarkRemoveDuplicates(b *testing.B) {
 	}
 }
 func BenchmarkStoreConnection(b *testing.B) {
+	conns := generateRandConnections(30000)
 	for _, bench := range []struct {
 		connCount int
 	}{
@@ -145,13 +146,14 @@ func BenchmarkStoreConnection(b *testing.B) {
 			b.ReportAllocs()
 
 			for n := 0; n < b.N; n++ {
-				ns.StoreConnections(generateRandConnections(bench.connCount))
+				ns.StoreConnections(conns[:bench.connCount])
 			}
 		})
 	}
 }
 
 func BenchmarkStoreClosedConnection(b *testing.B) {
+	conns := generateRandConnections(30000)
 	for _, bench := range []struct {
 		connCount int
 	}{
@@ -176,7 +178,7 @@ func BenchmarkStoreClosedConnection(b *testing.B) {
 			b.ReportAllocs()
 
 			for n := 0; n < b.N; n++ {
-				for _, c := range generateRandConnections(bench.connCount) {
+				for _, c := range conns[:bench.connCount] {
 					ns.StoreClosedConnection(c)
 				}
 			}
@@ -185,6 +187,9 @@ func BenchmarkStoreClosedConnection(b *testing.B) {
 }
 
 func BenchmarkConnectionsGet(b *testing.B) {
+	conns := generateRandConnections(30000)
+	closed := generateRandConnections(30000)
+
 	for _, bench := range []struct {
 		connCount   int
 		closedCount int
@@ -243,8 +248,8 @@ func BenchmarkConnectionsGet(b *testing.B) {
 
 			ns.Connections(DEBUGCLIENT) // Initial fetch to set up client
 
-			ns.StoreConnections(generateRandConnections(bench.connCount))
-			for _, c := range generateRandConnections(bench.closedCount) {
+			ns.StoreConnections(conns[:bench.connCount])
+			for _, c := range closed[:bench.closedCount] {
 				ns.StoreClosedConnection(c)
 			}
 

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -55,22 +55,26 @@ func TestRemoveDuplicates(t *testing.T) {
 		MonotonicRetransmits: 1,
 	}
 
+	ns := NewDefaultNetworkState()
+
 	conns := []ConnectionStats{conn1}
 	closedConns := []ConnectionStats{conn1}
-	assert.Equal(t, 1, len(removeDuplicates(conns, closedConns)))
+	assert.Equal(t, 1, len(ns.RemoveDuplicates(conns, closedConns)))
 
 	// conn1 and conn3 are duplicates
 	conns = []ConnectionStats{conn1}
 	closedConns = []ConnectionStats{conn3}
-	assert.Equal(t, 1, len(removeDuplicates(conns, closedConns)))
-	assert.Equal(t, conn3, removeDuplicates(conns, closedConns)[0])
+	assert.Equal(t, 1, len(ns.RemoveDuplicates(conns, closedConns)))
+	assert.Equal(t, conn3, ns.RemoveDuplicates(conns, closedConns)[0])
 
 	conns = []ConnectionStats{}
 	closedConns = []ConnectionStats{conn1, conn1, conn1, conn2, conn2, conn2, conn3, conn3, conn3}
-	assert.Equal(t, 2, len(removeDuplicates(conns, closedConns)))
+	assert.Equal(t, 2, len(ns.RemoveDuplicates(conns, closedConns)))
 }
 
 func BenchmarkRemoveDuplicates(b *testing.B) {
+	ns := NewDefaultNetworkState()
+
 	conn1 := ConnectionStats{
 		Pid:                  123,
 		Type:                 TCP,
@@ -117,7 +121,7 @@ func BenchmarkRemoveDuplicates(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		removeDuplicates(conns, closedConns)
+		ns.RemoveDuplicates(conns, closedConns)
 	}
 }
 func BenchmarkStoreConnection(b *testing.B) {

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -299,6 +299,14 @@ func (t *Tracer) timeoutForConn(c *ConnTuple) int64 {
 	return t.config.UDPConnTimeout.Nanoseconds()
 }
 
+// GetStats returns a map of statistics about the current tracer's internal state
+func (t *Tracer) GetStats() (map[string]interface{}, error) {
+	if t.state == nil {
+		return nil, fmt.Errorf("internal state not yet initialized")
+	}
+	return t.state.GetStats(), nil
+}
+
 // populatePortMapping reads the entire portBinding bpf map and populates the local port/address map.  A list of
 // closed ports will be returned
 func (t *Tracer) populatePortMapping(mp *bpflib.Map) ([]uint16, error) {

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -153,20 +153,12 @@ func (t *Tracer) Stop() {
 }
 
 func (t *Tracer) GetActiveConnections(clientID string) (*Connections, error) {
-	if err := t.updateState(); err != nil {
-		return nil, fmt.Errorf("error updating network-tracer state: %s", err)
-	}
-
-	return &Connections{Conns: t.state.Connections(clientID)}, nil
-}
-
-func (t *Tracer) updateState() error {
-	conns, err := t.getConnections()
+	latestConns, err := t.getConnections()
 	if err != nil {
-		return fmt.Errorf("error retrieving connections: %s", err)
+		return nil, fmt.Errorf("error retrieving connections: %s", err)
 	}
-	t.state.StoreConnections(conns)
-	return nil
+
+	return &Connections{Conns: t.state.Connections(clientID, latestConns)}, nil
 }
 
 func (t *Tracer) getConnections() ([]ConnectionStats, error) {

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -235,7 +235,8 @@ func (t *Tracer) removeEntries(mp, tcpMp *bpflib.Map, entries []*ConnTuple) {
 	for i := range entries {
 		err := t.m.DeleteElement(mp, unsafe.Pointer(entries[i]))
 		if err != nil {
-			log.Errorf("error when removing entry from connections bpf map: %s", err)
+			// It's possible some other process deleted this entry already (e.g. tcp_close)
+			log.Warnf("failed to remove entry from connections map: %s", err)
 		}
 
 		// We have to remove the PID to remove the element from the TCP Map since we don't use the pid there

--- a/ebpf/tracer_test.go
+++ b/ebpf/tracer_test.go
@@ -83,7 +83,7 @@ func TestTCPSendAndReceive(t *testing.T) {
 	connections := getConnections(t, tr)
 
 	conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, 10*clientMessageSize, int(conn.MonotonicSentBytes))
 	assert.Equal(t, 10*serverMessageSize, int(conn.MonotonicRecvBytes))
 	assert.Equal(t, 0, int(conn.MonotonicRetransmits))
@@ -142,10 +142,9 @@ func TestPreexistingConnectionDirection(t *testing.T) {
 }
 
 func TestTCPRemoveEntries(t *testing.T) {
-	tr, err := NewTracer(&Config{
-		CollectTCPConns: true,
-		TCPConnTimeout:  100 * time.Millisecond,
-	})
+	config := NewDefaultConfig()
+	config.TCPConnTimeout = 100 * time.Millisecond
+	tr, err := NewTracer(config)
 
 	if err != nil {
 		t.Fatal(err)
@@ -212,7 +211,7 @@ func TestTCPRemoveEntries(t *testing.T) {
 	assert.NotNil(t, err)
 
 	conn, ok := findConnection(c2.LocalAddr(), c2.RemoteAddr(), connections)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, clientMessageSize, int(conn.MonotonicSentBytes))
 	assert.Equal(t, 0, int(conn.MonotonicRecvBytes))
 	assert.Equal(t, 0, int(conn.MonotonicRetransmits))
@@ -266,7 +265,7 @@ func TestTCPRetransmit(t *testing.T) {
 	connections := getConnections(t, tr)
 
 	conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, 100*clientMessageSize, int(conn.MonotonicSentBytes))
 	assert.True(t, int(conn.MonotonicRetransmits) > 0)
 	assert.Equal(t, os.Getpid(), int(conn.Pid))
@@ -382,7 +381,7 @@ func TestTCPOverIPv6(t *testing.T) {
 	connections := getConnections(t, tr)
 
 	conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, clientMessageSize, int(conn.MonotonicSentBytes))
 	assert.Equal(t, serverMessageSize, int(conn.MonotonicRecvBytes))
 	assert.Equal(t, 0, int(conn.MonotonicRetransmits))
@@ -432,7 +431,7 @@ func TestTCPCollectionDisabled(t *testing.T) {
 
 	// Confirm that we could not find connection created above
 	_, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	assert.False(t, ok)
+	require.False(t, ok)
 
 	doneChan <- struct{}{}
 }
@@ -471,7 +470,7 @@ func TestUDPSendAndReceive(t *testing.T) {
 	connections := getConnections(t, tr)
 
 	conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, clientMessageSize, int(conn.MonotonicSentBytes))
 	assert.Equal(t, serverMessageSize, int(conn.MonotonicRecvBytes))
 	assert.Equal(t, os.Getpid(), int(conn.Pid))
@@ -517,7 +516,7 @@ func TestUDPDisabled(t *testing.T) {
 	connections := getConnections(t, tr)
 
 	_, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	assert.False(t, ok)
+	require.False(t, ok)
 
 	doneChan <- struct{}{}
 }

--- a/ebpf/tracer_unsupported.go
+++ b/ebpf/tracer_unsupported.go
@@ -27,3 +27,8 @@ func (t *Tracer) Stop() {}
 func (t *Tracer) GetActiveConnections(_ string) (*Connections, error) {
 	return nil, ErrNotImplemented
 }
+
+// GetStats returns a map of statistics about the current tracer's internal state
+func (t *Tracer) GetStats() (map[string]interface{}, error) {
+	return nil, ErrNotImplemented
+}


### PR DESCRIPTION
On nodes with large workloads that open & close a ton of connections in short periods of time, we were seeing growing memory usage (500MB after a few hours). 

This PR aims to fix that behavior by making sure we don't store data that we don't need, as well as making sure we clean up outdated stats objects.

**Previously**: 
```
BenchmarkRemoveDuplicates            500000          2300 ns/op        2776 B/op          47 allocs/op
BenchmarkStoreConnection/StoreConnection-100                30000         52687 ns/op       23392 B/op         510 allocs/op
BenchmarkStoreConnection/StoreConnection-1000                2000        584428 ns/op      274466 B/op        5042 allocs/op
BenchmarkStoreConnection/StoreConnection-10000                300       5352960 ns/op     2494785 B/op       50283 allocs/op
BenchmarkStoreConnection/StoreConnection-30000                100      18381628 ns/op     8431557 B/op      151136 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-100                20000         69975 ns/op       26401 B/op         600 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-1000                2000        701545 ns/op      264200 B/op        6000 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-10000                200       7319963 ns/op     2655720 B/op       60002 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-30000                 50      24365740 ns/op     8170518 B/op      180046 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-0                            20000         85885 ns/op       54929 B/op         420 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-50                           20000         88785 ns/op       54933 B/op         420 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-100                          20000         87040 ns/op       54934 B/op         420 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-0                            2000        872430 ns/op      534662 B/op        4048 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-500                          2000        865562 ns/op      534903 B/op        4049 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-1000                         2000        870050 ns/op      535143 B/op        4051 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-0                            100      11108402 ns/op     7648580 B/op       40341 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-5000                         100      11476827 ns/op     7711009 B/op       40542 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-10000                        100      10933214 ns/op     7789443 B/op       40743 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-0                             50      36319458 ns/op    24675338 B/op      121695 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-15000                         30      38335357 ns/op    25343252 B/op      124126 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-30000                         30      38696720 ns/op    25943834 B/op      126155 allocs/op
PASS
ok      command-line-arguments    40.778s
```

**After a number of improvements**: 
```
BenchmarkRemoveDuplicates      	 1000000	      1445 ns/op	     568 B/op	      31 allocs/op
BenchmarkStoreConnection/StoreConnection-100         	   30000	     40912 ns/op	   13680 B/op	     409 allocs/op
BenchmarkStoreConnection/StoreConnection-1000        	    3000	    465804 ns/op	  178353 B/op	    4041 allocs/op
BenchmarkStoreConnection/StoreConnection-10000       	     300	   4379600 ns/op	 1534558 B/op	   40281 allocs/op
BenchmarkStoreConnection/StoreConnection-30000       	     100	  14473710 ns/op	 5551198 B/op	  121134 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-100         	   20000	     58651 ns/op	   18401 B/op	     599 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-1000        	    2000	    626896 ns/op	  184182 B/op	    5999 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-10000       	     200	   6298141 ns/op	 1854121 B/op	   59952 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-30000       	     100	  21229987 ns/op	 5635618 B/op	  179723 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-0                     	   50000	     27124 ns/op	   24528 B/op	       9 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-50                    	   50000	     27632 ns/op	   24528 B/op	       9 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-100                   	   50000	     30818 ns/op	   24529 B/op	       9 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-0                    	   10000	    241631 ns/op	  196576 B/op	      12 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-500                  	   10000	    253815 ns/op	  196616 B/op	      12 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-1000                 	   10000	    243329 ns/op	  196648 B/op	      12 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-0                   	     300	   4754020 ns/op	 4469440 B/op	      56 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-5000                	     300	   4661103 ns/op	 4482224 B/op	     123 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-10000               	     300	   4666075 ns/op	 4500120 B/op	     190 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-0                   	     100	  16389316 ns/op	14495609 B/op	     338 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-15000               	     100	  17246297 ns/op	14615552 B/op	     943 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-30000               	     100	  16954577 ns/op	14709854 B/op	    1548 allocs/op
PASS
ok  	command-line-arguments	43.379s
```

**Removing active connection storage (& merging `ConnectionsGet` + `StoreConnection`)**: 

```
BenchmarkRemoveDuplicates      	 1000000	      1549 ns/op	     568 B/op	      31 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-100         	   20000	     69614 ns/op	   18401 B/op	     599 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-1000        	    2000	   1114043 ns/op	  184181 B/op	    5999 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-10000       	      50	  22068868 ns/op	 1896434 B/op	   59811 allocs/op
BenchmarkStoreClosedConnection/StoreClosedConnection-30000       	      50	  37215887 ns/op	 5751271 B/op	  179445 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-0                     	   20000	     93261 ns/op	   34365 B/op	     412 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-50                    	   20000	     69812 ns/op	   34367 B/op	     412 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-100-100                   	   20000	     72119 ns/op	   34368 B/op	     412 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-0                    	    2000	    664163 ns/op	  310069 B/op	    4015 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-500                  	    2000	    634678 ns/op	  310269 B/op	    4016 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-1000-1000                 	    2000	    685621 ns/op	  310426 B/op	    4017 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-0                   	     100	  10077985 ns/op	 5498000 B/op	   40127 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-5000                	     100	  10424169 ns/op	 5536285 B/op	   40328 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-10000-10000               	     100	  11805941 ns/op	 5589957 B/op	   40529 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-0                   	      50	  37313849 ns/op	18039313 B/op	  120653 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-15000               	      30	  35325675 ns/op	18509785 B/op	  123083 allocs/op
BenchmarkConnectionsGet/ConnectionsGet-30000-30000               	      30	  40856162 ns/op	18824539 B/op	  125103 allocs/op
PASS
ok  	command-line-arguments	34.152s
```