### PR TITLE
Use client_id for calls to remote network tracer (calls over unix socket)

### DIFF
--- a/checks/net.go
+++ b/checks/net.go
@@ -139,7 +139,7 @@ func (c *ConnectionsCheck) getConnections() ([]ebpf.ConnectionStats, error) {
 		return nil, ErrTracerStillNotInitialized
 	}
 
-	return tu.GetConnections()
+	return tu.GetConnections(c.tracerClientID)
 }
 
 // Connections are split up into a chunks of at most 100 connections per message to

--- a/net/network_linux.go
+++ b/net/network_linux.go
@@ -73,9 +73,8 @@ func GetRemoteNetworkTracerUtil() (*RemoteNetTracerUtil, error) {
 }
 
 // GetConnections returns a set of active network connections, retrieved from the network tracer service
-func (r *RemoteNetTracerUtil) GetConnections() ([]ebpf.ConnectionStats, error) {
-	// Otherwise, get it remotely (via unix socket), and parse from JSON
-	resp, err := r.httpClient.Get(connectionsURL)
+func (r *RemoteNetTracerUtil) GetConnections(clientID string) ([]ebpf.ConnectionStats, error) {
+	resp, err := r.httpClient.Get(fmt.Sprintf("%s?client_id=%s", connectionsURL, clientID))
 	if err != nil {
 		return nil, err
 	} else if resp.StatusCode != http.StatusOK {

--- a/net/network_nolinux.go
+++ b/net/network_nolinux.go
@@ -18,7 +18,7 @@ func GetRemoteNetworkTracerUtil() (*RemoteNetTracerUtil, error) {
 }
 
 // GetConnections is only implemented on linux
-func (r *RemoteNetTracerUtil) GetConnections() ([]ebpf.ConnectionStats, error) {
+func (r *RemoteNetTracerUtil) GetConnections(clientID string) ([]ebpf.ConnectionStats, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 


### PR DESCRIPTION
Noticed that we're currently only adding it as a param to the local network tracer (which is/will likely not be used in production environments).

This fixes that.