### PR TITLE
[proc] revert to manual windows agent version tag and bump to 6.10.0

### DIFF
--- a/gorake.rb
+++ b/gorake.rb
@@ -25,7 +25,7 @@ def go_build(program, opts={})
   agentversion = ENV["AGENT_VERSION"] || ENV["PROCESS_AGENT_VERSION"] || "0.99.0"
 
   # NOTE: This value is currently hardcoded and needs to be manually incremented during release
-  winversion = "6.9.0".split(".")
+  winversion = "6.10.0".split(".")
 
   vars = {}
   vars["#{dd}.Version"] = agentversion

--- a/gorake.rb
+++ b/gorake.rb
@@ -24,7 +24,8 @@ def go_build(program, opts={})
   goversion = `go version`.strip
   agentversion = ENV["AGENT_VERSION"] || ENV["PROCESS_AGENT_VERSION"] || "0.99.0"
 
-  winversion = get_latest_tag()
+  # NOTE: This value is currently hardcoded and needs to be manually incremented during release
+  winversion = "6.9.0".split(".")
 
   vars = {}
   vars["#{dd}.Version"] = agentversion
@@ -84,11 +85,6 @@ def go_build(program, opts={})
   end
 end
 
-def get_latest_tag()
-  `git tag --merged HEAD --sort=-taggerdate`.split("\n").select do |t|
-      t.split(".").size == 3
-  end.first
-end
 
 def go_lint(path)
   out = `golint #{path}/*.go`


### PR DESCRIPTION
This reverts https://github.com/DataDog/datadog-process-agent/pull/237 and bump windows version to 6.10.0. cc: @DataDog/burrito 