### PR TITLE
[windows] fix process name.  On some system processes, WMI doesn't

### DIFF
--- a/checks/allprocesses_windows.go
+++ b/checks/allprocesses_windows.go
@@ -398,9 +398,15 @@ func (cp *cachedProcess) fill(proc *Win32_Process) (err error) {
 	cp.userName, err = getUsernameForProcess(cp.procHandle)
 	if err != nil {
 		log.Infof("Couldn't get process username %v %v", proc.ProcessID, err)
-		return err
 	}
 	cp.executablePath = *proc.ExecutablePath
+	if len(cp.executablePath) == 0 {
+		// some system processes don't give us the executable path variable.  Just
+		// give the executable name
+
+		cp.executablePath = proc.Name
+		log.Debugf("Setting alternate executable path (name) %d %s", proc.ProcessID, cp.executablePath)
+	}
 	cp.commandLine = *proc.CommandLine
 	var parsedargs []string
 	if len(cp.commandLine) == 0 {


### PR DESCRIPTION
have the executable path (not sure why, but it's not in the response)
Use the process name to give some information back to the user