### PR TITLE
[proc] bump datadog-agent dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
   version = "4.8"
 
 [[projects]]
-  digest = "1:d0724fd3ad246a588b45b31d16da06d93a3aa91f01d5f43027fe818a435c37d7"
+  digest = "1:8c24e5c45e58978e89cfaca71220a44ed623f39cb961c079610aa7213c6fe9bf"
   name = "github.com/DataDog/datadog-agent"
   packages = [
     "cmd/agent/api/response",
@@ -40,6 +40,7 @@
     "pkg/util",
     "pkg/util/cache",
     "pkg/util/clusteragent",
+    "pkg/util/common",
     "pkg/util/containers",
     "pkg/util/containers/collectors",
     "pkg/util/containers/metrics",
@@ -62,7 +63,7 @@
     "pkg/version",
   ]
   pruneopts = ""
-  revision = "d7b476d9424edcdcec13d69148a3230eae771def"
+  revision = "4aa90bd394b62b0d3e3f15703c6e459c1c477fbc"
 
 [[projects]]
   digest = "1:7a91a175c283b21c6e99edc1b2fb82fe11eb5b42e7a28a2a67b17d9c28ad1855"
@@ -86,6 +87,14 @@
   revision = "c8f74f1344dd41bc49ec4d3c2377c526aaedfd20"
 
 [[projects]]
+  digest = "1:e9ca79fa28ff0fe0271b63d2d30f4118643746610cd0d75603c7b4255a44f161"
+  name = "github.com/DataDog/viper"
+  packages = ["."]
+  pruneopts = ""
+  revision = "23ced3bc6b3751855704445e48da2c53075ade86"
+  version = "v1.4.0"
+
+[[projects]]
   digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"
   name = "github.com/DataDog/zstd"
   packages = ["."]
@@ -101,12 +110,12 @@
   version = "v0.4.11"
 
 [[projects]]
-  branch = "master"
-  digest = "1:92c4393f5d7f8a1a30e1d53a53a55335f7dfbec90dbce2ab98102d637b2ced43"
+  digest = "1:f82b8ac36058904227087141017bb82f4b0fc58272990a4cdae3e2d6d222644e"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
   pruneopts = ""
-  revision = "b12b22c5341f0c26d88c4d66176330500e84db68"
+  revision = "5d049714c4a64225c3c79a7cf7d02f7fb5b96338"
+  version = "1.0.0"
 
 [[projects]]
   digest = "1:63776251fbaa60062742412a9d2fa1e4b7cd24bcf5527fa9656b314ea8d60913"
@@ -547,7 +556,7 @@
   revision = "65c1f6f8f0fc1e2185eb9863a3bc751496404259"
 
 [[projects]]
-  digest = "1:02715a2fb4b9279af36651a59a51dd4164eb689bd6785874811899f43eeb2a54"
+  digest = "1:066c1020d667e25a0614b56aee1f9ac47e75c77de98eddfb51e9be02c68c1577"
   name = "github.com/shirou/gopsutil"
   packages = [
     "cpu",
@@ -558,8 +567,8 @@
     "process",
   ]
   pruneopts = ""
-  revision = "8048a2e9c5773235122027dd585cf821b2af1249"
-  version = "v2.18.07"
+  revision = "071446942108a03a13cf0717275ad3bdbcb691b4"
+  version = "v2.19.01"
 
 [[projects]]
   branch = "master"
@@ -603,14 +612,6 @@
   pruneopts = ""
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
-
-[[projects]]
-  digest = "1:3dab237cd3263a290d771d133fed777bb56c22e380b00ebe92e6531d5c8d3d0c"
-  name = "github.com/spf13/viper"
-  packages = ["."]
-  pruneopts = ""
-  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
-  version = "v1.0.2"
 
 [[projects]]
   digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
@@ -658,7 +659,8 @@
   revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
 
 [[projects]]
-  digest = "1:da939d913a9f7bb1a0841c2066029f940f12a79b7693d3456dd220fa2ed74879"
+  branch = "master"
+  digest = "1:fcf1709e13fe39cf6343de351e86a0683cc593fe02f5cdb3c0757084bca2fa7b"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -670,7 +672,7 @@
     "windows/svc/mgr",
   ]
   pruneopts = ""
-  revision = "95c6576299259db960f6c5b9b69ea52422860fce"
+  revision = "a9d3bda3a223baa6bba6ef412cb273f0fd163c05"
 
 [[projects]]
   digest = "1:75a8b2050f6576c5ebc0f4985ad976cca7e4c1834c73a2a15d522a2d8d143963"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/DataDog/datadog-agent"
-  revision = "d7b476d9424edcdcec13d69148a3230eae771def"
+  revision = "4aa90bd394b62b0d3e3f15703c6e459c1c477fbc"
 
 [[constraint]]
   name = "github.com/DataDog/gopsutil"

--- a/cmd/agent/main_common.go
+++ b/cmd/agent/main_common.go
@@ -112,11 +112,8 @@ func runAgent(exit chan bool) {
 	}
 
 	// Tagger must be initialized after agent config has been setup (via config.SetupDDAgentConfig)
-	if err := tagger.Init(); err == nil {
-		defer tagger.Stop()
-	} else {
-		log.Errorf("unable to initialize Datadog entity tagger: %s", err)
-	}
+	tagger.Init()
+	defer tagger.Stop()
 
 	networkConf, err := config.NewYamlIfExists(opts.netConfigPath)
 	if err != nil {


### PR DESCRIPTION
I pinned datadog-agent dependency to 6.10.0-rc.1 for containers-integrations team has some tagger updates. @DataDog/burrito 