### PR TITLE
Use BPF monotonic clock time in network state management

### DIFF
--- a/cmd/network-tracer/tracer.go
+++ b/cmd/network-tracer/tracer.go
@@ -90,7 +90,7 @@ func (nt *NetworkTracer) Run() {
 		log.Tracef("/connections: %d connections, %d bytes", len(cs.Conns), len(buf))
 	})
 
-	http.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
+	http.HandleFunc("/debug/stats", func(w http.ResponseWriter, req *http.Request) {
 		stats, err := nt.tracer.GetStats()
 		if err != nil {
 			log.Errorf("unable to retrieve tracer stats: %s", err)

--- a/ebpf/event.go
+++ b/ebpf/event.go
@@ -59,8 +59,8 @@ __u32 retransmits;
 */
 type TCPStats C.tcp_stats_t
 
-func (cs *ConnStatsWithTimestamp) isExpired(latestTime int64, timeout int64) bool {
-	return latestTime-int64(cs.timestamp) > timeout
+func (cs *ConnStatsWithTimestamp) isExpired(latestTime uint64, timeout uint64) bool {
+	return latestTime-uint64(cs.timestamp) > timeout
 }
 
 func connStats(t *ConnTuple, s *ConnStatsWithTimestamp, tcpStats *TCPStats) ConnectionStats {


### PR DESCRIPTION
This replaces the `time.Time` objects that we've been using, which allows:
  - Smaller `stats{}` objects
  - Consistent timings used when expiring connections and their stats objects.

@DataDog/burrito 