### PR TITLE
Use common agent config package for parsing process-config

### DIFF
--- a/cmd/network-tracer/main.go
+++ b/cmd/network-tracer/main.go
@@ -140,8 +140,8 @@ func versionString() string {
 }
 
 func parseConfig() *config.AgentConfig {
-	yamlConf, err := config.NewYamlIfExists(opts.configPath) // --yamlConfig
-	if err != nil {                                          // Will return nil if no Yaml file exists
+	yamlConf, err := config.NetworkConfigIfExists(opts.configPath) // --yamlConfig
+	if err != nil {                                                // Will return nil if no Yaml file exists
 		log.Criticalf("Error reading YAML formatted config: %s", err)
 		os.Exit(1)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -207,7 +207,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 		CollectDockerNetwork:   true,
 
 		// DataScrubber to hide command line sensitive words
-		Scrubber: NewDefaultDataScrubber(),
+		Scrubber:  NewDefaultDataScrubber(),
+		Blacklist: make([]*regexp.Regexp, 0),
 
 		// Windows process config
 		Windows: WindowsConfig{
@@ -241,7 +242,7 @@ func isRunningInKubernetes() bool {
 
 // NewAgentConfig returns an AgentConfig using a configuration file. It can be nil
 // if there is no file available. In this case we'll configure only via environment.
-func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig, networkYaml *YamlAgentConfig) (*AgentConfig, error) {
+func NewAgentConfig(agentIni *File, networkYaml *NetworkAgentConfig, yamlPath string) (*AgentConfig, error) {
 	var err error
 	cfg := NewDefaultAgentConfig()
 
@@ -361,8 +362,8 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig, networkYaml *Yam
 	}
 
 	// For Agents >= 6 we will have a YAML config file to use.
-	if agentYaml != nil {
-		if cfg, err = mergeYamlConfig(cfg, agentYaml); err != nil {
+	if util.PathExists(yamlPath) {
+		if err := cfg.loadProcessYamlConfig(yamlPath); err != nil {
 			return nil, err
 		}
 	}
@@ -415,7 +416,7 @@ func NewAgentConfig(agentIni *File, agentYaml *YamlAgentConfig, networkYaml *Yam
 
 // NewNetworkAgentConfig returns a network-tracer specific AgentConfig using a configuration file. It can be nil
 // if there is no file available. In this case we'll configure only via environment.
-func NewNetworkAgentConfig(networkYaml *YamlAgentConfig) (*AgentConfig, error) {
+func NewNetworkAgentConfig(networkYaml *NetworkAgentConfig) (*AgentConfig, error) {
 	cfg := NewDefaultAgentConfig()
 	var err error
 

--- a/config/testdata/TestDDAgentConfigBothVersions.yaml
+++ b/config/testdata/TestDDAgentConfigBothVersions.yaml
@@ -1,0 +1,7 @@
+api_key: apikey_20
+
+process_config:
+  process_dd_url: http://my-process-app.datadoghq.com
+  queue_size: 10
+  windows:
+      args_refresh_interval: 40

--- a/config/testdata/TestDDAgentConfigYamlAndNetworkConfig.yaml
+++ b/config/testdata/TestDDAgentConfigYamlAndNetworkConfig.yaml
@@ -1,0 +1,14 @@
+api_key: apikey_20
+
+process_agent_enabled: true
+process_config:
+  process_dd_url: http://my-process-app.datadoghq.com
+  enabled: 'true'
+  queue_size: 10
+  intervals:
+    container: 8
+    process: 30
+  windows:
+    args_refresh_interval: 100
+    add_new_args: false
+  scrub_args: false

--- a/config/testdata/TestDDAgentConfigYamlOnly-2.yaml
+++ b/config/testdata/TestDDAgentConfigYamlOnly-2.yaml
@@ -1,0 +1,13 @@
+api_key: apikey_20
+
+process_agent_enabled: true
+process_config:
+  enabled: 'false'
+  queue_size: 10
+  intervals:
+      container: 8
+      process: 30
+  windows:
+      args_refresh_interval: -1
+      add_new_args: true
+  scrub_args: true

--- a/config/testdata/TestDDAgentConfigYamlOnly-3.yaml
+++ b/config/testdata/TestDDAgentConfigYamlOnly-3.yaml
@@ -1,0 +1,9 @@
+api_key: apikey_20
+
+process_agent_enabled: true
+process_config:
+  enabled: 'disabled'
+  queue_size: 10
+  intervals:
+      container: 8
+      process: 30

--- a/config/testdata/TestDDAgentConfigYamlOnly-4.yaml
+++ b/config/testdata/TestDDAgentConfigYamlOnly-4.yaml
@@ -1,0 +1,13 @@
+api_key: apikey_20
+
+process_agent_enabled: true
+process_config:
+  enabled: 'disabled'
+  additional_endpoints:
+    https://process.datadoghq.eu:
+      - foo
+      - bar
+  queue_size: 10
+  intervals:
+      container: 8
+      process: 30

--- a/config/testdata/TestDDAgentConfigYamlOnly-5.yaml
+++ b/config/testdata/TestDDAgentConfigYamlOnly-5.yaml
@@ -1,0 +1,7 @@
+api_key: apikey_20
+site: datadoghq.eu
+
+process_agent_enabled: true
+process_config:
+  enabled: 'true'
+  process_dd_url: http://test-process.datadoghq.com

--- a/config/testdata/TestDDAgentConfigYamlOnly-6.yaml
+++ b/config/testdata/TestDDAgentConfigYamlOnly-6.yaml
@@ -1,0 +1,6 @@
+api_key: apikey_20
+site: datacathq.eu
+
+process_agent_enabled: true
+process_config:
+  enabled: 'true'

--- a/config/testdata/TestDDAgentConfigYamlOnly.yaml
+++ b/config/testdata/TestDDAgentConfigYamlOnly.yaml
@@ -1,0 +1,13 @@
+api_key: apikey_20
+
+process_agent_enabled: true
+process_config:
+  enabled: 'true'
+  queue_size: 10
+  intervals:
+      container: 8
+      process: 30
+  windows:
+      args_refresh_interval: 100
+      add_new_args: false
+  scrub_args: false

--- a/config/testdata/TestEnvSiteConfig-2.yaml
+++ b/config/testdata/TestEnvSiteConfig-2.yaml
@@ -1,0 +1,7 @@
+api_key: apikey_20
+
+process_agent_enabled: true
+process_config:
+  enabled: 'true'
+  process_dd_url: https://process.datadoghq.eu
+

--- a/config/testdata/TestEnvSiteConfig-3.yaml
+++ b/config/testdata/TestEnvSiteConfig-3.yaml
@@ -1,0 +1,8 @@
+api_key: apikey_20
+site: datacathq.eu
+
+process_agent_enabled: true
+process_config:
+  enabled: 'true'
+  process_dd_url: https://burrito.com
+

--- a/config/testdata/TestEnvSiteConfig.yaml
+++ b/config/testdata/TestEnvSiteConfig.yaml
@@ -1,0 +1,6 @@
+api_key: apikey_20
+site: datadoghq.io
+
+process_agent_enabled: true
+process_config:
+  enabled: 'true'

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -160,6 +160,7 @@ func (a *AgentConfig) loadProcessYamlConfig(path string) error {
 		r, err := regexp.Compile(b)
 		if err != nil {
 			log.Warnf("Ignoring invalid blacklist pattern: %s", b)
+			continue
 		}
 		a.Blacklist = append(a.Blacklist, r)
 	}

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -7,74 +7,20 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/cihub/seelog"
-	"gopkg.in/yaml.v2"
-
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	ddutil "github.com/DataDog/datadog-agent/pkg/util"
-
 	"github.com/DataDog/datadog-process-agent/util"
+	log "github.com/cihub/seelog"
+	yaml "gopkg.in/yaml.v2"
 )
 
-// YamlAgentConfig is a structure used for marshaling the datadog.yaml configuration
+const (
+	ns = "process_config"
+)
+
+// NetworkAgentConfig is a structure used for marshaling the network-tracer.yaml configuration
 // available in Agent versions >= 6
-type YamlAgentConfig struct {
-	APIKey string `yaml:"api_key"`
-	Site   string `yaml:"site"`
-	// Whether or not the process-agent should output logs to console
-	LogToConsole bool `yaml:"log_to_console"`
-	// Process-specific configuration
-	Process struct {
-		// A string indicate the enabled state of the Agent.
-		// If "false" (the default) we will only collect containers.
-		// If "true" we will collect containers and processes.
-		// If "disabled" the agent will be disabled altogether and won't start.
-		Enabled string `yaml:"enabled"`
-		// The full path to the file where process-agent logs will be written.
-		LogFile string `yaml:"log_file"`
-		// The interval, in seconds, at which we will run each check. If you want consistent
-		// behavior between real-time you may set the Container/ProcessRT intervals to 10.
-		// Defaults to 10s for normal checks and 2s for others.
-		Intervals struct {
-			Container         int `yaml:"container"`
-			ContainerRealTime int `yaml:"container_realtime"`
-			Process           int `yaml:"process"`
-			ProcessRealTime   int `yaml:"process_realtime"`
-			Connections       int `yaml:"connections"`
-		} `yaml:"intervals"`
-		// A list of regex patterns that will exclude a process if matched.
-		BlacklistPatterns []string `yaml:"blacklist_patterns"`
-		// Enable/Disable the DataScrubber to obfuscate process args
-		// XXX: Using a bool pointer to differentiate between empty and set.
-		ScrubArgs *bool `yaml:"scrub_args,omitempty"`
-		// A custom word list to enhance the default one used by the DataScrubber
-		CustomSensitiveWords []string `yaml:"custom_sensitive_words"`
-		// Strips all process arguments
-		StripProcessArguments bool `yaml:"strip_proc_arguments"`
-		// How many check results to buffer in memory when POST fails. The default is usually fine.
-		QueueSize int `yaml:"queue_size"`
-		// The maximum number of file descriptors to open when collecting net connections.
-		// Only change if you are running out of file descriptors from the Agent.
-		MaxProcFDs int `yaml:"max_proc_fds"`
-		// The maximum number of processes, or containers per message.
-		// Only change if the defaults are causing issues.
-		MaxPerMessage int `yaml:"max_per_message"`
-		// Overrides the path to the Agent bin used for getting the hostname. The default is usually fine.
-		DDAgentBin string `yaml:"dd_agent_bin"`
-		// Overrides of the environment we pass to fetch the hostname. The default is usually fine.
-		DDAgentEnv []string `yaml:"dd_agent_env"`
-		// Optional additional pairs of endpoint_url => []apiKeys to submit to other locations.
-		AdditionalEndpoints map[string][]string `yaml:"additional_endpoints"`
-		// Windows-specific configuration goes in this section.
-		Windows struct {
-			// Sets windows process table refresh rate (in number of check runs)
-			ArgsRefreshInterval int `yaml:"args_refresh_interval"`
-			// Controls getting process arguments immediately when a new process is discovered
-			// XXX: Using a bool pointer to differentiate between empty and set.
-			AddNewArgs *bool `yaml:"add_new_args,omitempty"`
-		} `yaml:"windows"`
-	} `yaml:"process_config"`
-	// Network-tracing specific configuration
+type NetworkAgentConfig struct { // Network-tracing specific configuration
 	Network struct {
 		// A string indicating the enabled state of the network tracer.
 		NetworkTracingEnabled bool `yaml:"enabled"`
@@ -98,18 +44,12 @@ type YamlAgentConfig struct {
 	} `yaml:"network_tracer_config"`
 }
 
-// NewYamlIfExists returns a new YamlAgentConfig if the given configPath is exists.
-func NewYamlIfExists(configPath string) (*YamlAgentConfig, error) {
-	var yamlConf YamlAgentConfig
+// NetworkConfigIfExists returns a new NetworkAgentConfig if the given configPath is exists.
+func NetworkConfigIfExists(path string) (*NetworkAgentConfig, error) {
+	var yamlConf NetworkAgentConfig
 
-	// Set default values for booleans otherwise it will default to false.
-	defaultScrubArgs := true
-	yamlConf.Process.ScrubArgs = &defaultScrubArgs
-	defaultNewArgs := true
-	yamlConf.Process.Windows.AddNewArgs = &defaultNewArgs
-
-	if util.PathExists(configPath) {
-		lines, err := util.ReadLines(configPath)
+	if util.PathExists(path) {
+		lines, err := util.ReadLines(path)
 		if err != nil {
 			return nil, fmt.Errorf("read error: %s", err)
 		}
@@ -121,115 +61,7 @@ func NewYamlIfExists(configPath string) (*YamlAgentConfig, error) {
 	return nil, nil
 }
 
-func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig, error) {
-	agentConf.APIEndpoints[0].APIKey = yc.APIKey
-
-	if enabled, err := isAffirmative(yc.Process.Enabled); enabled {
-		agentConf.Enabled = true
-		agentConf.EnabledChecks = processChecks
-	} else if strings.ToLower(yc.Process.Enabled) == "disabled" {
-		agentConf.Enabled = false
-	} else if !enabled && err == nil {
-		agentConf.Enabled = true
-		agentConf.EnabledChecks = containerChecks
-	}
-	url, err := url.Parse(ddconfig.GetMainEndpoint("https://process.", "process_config.process_dd_url"))
-	if err != nil {
-		return nil, fmt.Errorf("error parsing process_dd_url: %s", err)
-	}
-	agentConf.APIEndpoints[0].Endpoint = url
-	if yc.LogToConsole {
-		agentConf.LogToConsole = true
-	}
-	if yc.Process.LogFile != "" {
-		agentConf.LogFile = yc.Process.LogFile
-	}
-	if yc.Process.Intervals.Container != 0 {
-		log.Infof("Overriding container check interval to %ds", yc.Process.Intervals.Container)
-		agentConf.CheckIntervals["container"] = time.Duration(yc.Process.Intervals.Container) * time.Second
-	}
-	if yc.Process.Intervals.ContainerRealTime != 0 {
-		log.Infof("Overriding real-time container check interval to %ds", yc.Process.Intervals.ContainerRealTime)
-		agentConf.CheckIntervals["rtcontainer"] = time.Duration(yc.Process.Intervals.ContainerRealTime) * time.Second
-	}
-	if yc.Process.Intervals.Process != 0 {
-		log.Infof("Overriding process check interval to %ds", yc.Process.Intervals.Process)
-		agentConf.CheckIntervals["process"] = time.Duration(yc.Process.Intervals.Process) * time.Second
-	}
-	if yc.Process.Intervals.ProcessRealTime != 0 {
-		log.Infof("Overriding real-time process check interval to %ds", yc.Process.Intervals.ProcessRealTime)
-		agentConf.CheckIntervals["rtprocess"] = time.Duration(yc.Process.Intervals.Process) * time.Second
-	}
-	if yc.Process.Intervals.Connections != 0 {
-		log.Infof("Overriding connections check interval to %ds", yc.Process.Intervals.Connections)
-		agentConf.CheckIntervals["connections"] = time.Duration(yc.Process.Intervals.Connections) * time.Second
-	}
-	blacklist := make([]*regexp.Regexp, 0, len(yc.Process.BlacklistPatterns))
-	for _, b := range yc.Process.BlacklistPatterns {
-		r, err := regexp.Compile(b)
-		if err != nil {
-			log.Warnf("Invalid blacklist pattern: %s", b)
-		}
-		blacklist = append(blacklist, r)
-	}
-	agentConf.Blacklist = blacklist
-
-	// DataScrubber
-	if yc.Process.ScrubArgs != nil {
-		agentConf.Scrubber.Enabled = *yc.Process.ScrubArgs
-	}
-	agentConf.Scrubber.AddCustomSensitiveWords(yc.Process.CustomSensitiveWords)
-	if yc.Process.StripProcessArguments {
-		agentConf.Scrubber.StripAllArguments = yc.Process.StripProcessArguments
-	}
-
-	if yc.Process.QueueSize > 0 {
-		agentConf.QueueSize = yc.Process.QueueSize
-	}
-	if yc.Process.MaxProcFDs > 0 {
-		agentConf.MaxProcFDs = yc.Process.MaxProcFDs
-	}
-	if yc.Process.MaxPerMessage > 0 {
-		if yc.Process.MaxPerMessage <= maxMessageBatch {
-			agentConf.MaxPerMessage = yc.Process.MaxPerMessage
-		} else {
-			log.Warn("Overriding the configured item count per message limit because it exceeds maximum")
-		}
-	}
-	agentConf.DDAgentBin = defaultDDAgentBin
-	if yc.Process.DDAgentBin != "" {
-		agentConf.DDAgentBin = yc.Process.DDAgentBin
-	}
-
-	if yc.Process.Windows.ArgsRefreshInterval != 0 {
-		agentConf.Windows.ArgsRefreshInterval = yc.Process.Windows.ArgsRefreshInterval
-	}
-	if yc.Process.Windows.AddNewArgs != nil {
-		agentConf.Windows.AddNewArgs = *yc.Process.Windows.AddNewArgs
-	}
-
-	for endpointURL, apiKeys := range yc.Process.AdditionalEndpoints {
-		u, err := url.Parse(endpointURL)
-		if err != nil {
-			return nil, fmt.Errorf("invalid additional endpoint url '%s': %s", endpointURL, err)
-		}
-		for _, k := range apiKeys {
-			agentConf.APIEndpoints = append(agentConf.APIEndpoints, APIEndpoint{
-				APIKey:   k,
-				Endpoint: u,
-			})
-		}
-	}
-
-	// Pull additional parameters from the global config file.
-	agentConf.LogLevel = ddconfig.Datadog.GetString("log_level")
-	agentConf.StatsdPort = ddconfig.Datadog.GetInt("dogstatsd_port")
-	agentConf.Transport = ddutil.CreateHTTPTransport()
-
-	return agentConf, nil
-}
-
-func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *YamlAgentConfig) (*AgentConfig, error) {
+func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *NetworkAgentConfig) (*AgentConfig, error) {
 	agentConf.DisableTCPTracing = networkConf.Network.DisableTCP
 	agentConf.DisableUDPTracing = networkConf.Network.DisableUDP
 	agentConf.DisableIPv6Tracing = networkConf.Network.DisableIPv6
@@ -263,25 +95,149 @@ func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *YamlAgentConfig
 	}
 
 	// Pull additional parameters from the global config file.
-	agentConf.LogLevel = ddconfig.Datadog.GetString("log_level")
-	agentConf.StatsdPort = ddconfig.Datadog.GetInt("dogstatsd_port")
+	agentConf.LogLevel = config.Datadog.GetString("log_level")
+	agentConf.StatsdPort = config.Datadog.GetInt("dogstatsd_port")
 
 	return agentConf, nil
 }
 
-// SetupDDAgentConfig initializes the datadog-agent config with a YAML file.
-// This is required for configuration to be available for container listeners.
-func SetupDDAgentConfig(configPath string) error {
-	ddconfig.Datadog.AddConfigPath(configPath)
-	// If they set a config file directly, let's try to honor that
-	if strings.HasSuffix(configPath, ".yaml") {
-		ddconfig.Datadog.SetConfigFile(configPath)
+func key(pieces ...string) string {
+	return strings.Join(pieces, ".")
+}
+
+// Process-specific configuration
+func (a *AgentConfig) loadProcessYamlConfig(path string) error {
+	config.Datadog.AddConfigPath(path)
+	if strings.HasSuffix(path, ".yaml") { // If they set a config file directly, let's try to honor that
+		config.Datadog.SetConfigFile(path)
 	}
 
-	// load the configuration
-	if err := ddconfig.Load(); err != nil {
-		return fmt.Errorf("unable to load Datadog config file: %s", err)
+	if err := config.Load(); err != nil {
+		return err
 	}
+
+	URL, err := url.Parse(config.GetMainEndpoint("https://process.", key(ns, "process_dd_url")))
+	if err != nil {
+		return fmt.Errorf("error parsing process_dd_url: %s", err)
+	}
+
+	a.APIEndpoints[0].APIKey = config.Datadog.GetString("api_key")
+	a.APIEndpoints[0].Endpoint = URL
+
+	// A string indicate the enabled state of the Agent.
+	// If "false" (the default) we will only collect containers.
+	// If "true" we will collect containers and processes.
+	// If "disabled" the agent will be disabled altogether and won't start.
+	enabled := config.Datadog.GetString(key(ns, "enabled"))
+	if ok, err := isAffirmative(enabled); ok {
+		a.Enabled, a.EnabledChecks = true, processChecks
+	} else if enabled == "disabled" {
+		a.Enabled = false
+	} else if !ok && err == nil {
+		a.Enabled, a.EnabledChecks = true, containerChecks
+	}
+
+	// Whether or not the process-agent should output logs to console
+	if config.Datadog.GetBool("log_to_console") {
+		a.LogToConsole = true
+	}
+	// The full path to the file where process-agent logs will be written.
+	if logFile := config.Datadog.GetString(key(ns, "log_file")); logFile != "" {
+		a.LogFile = logFile
+	}
+
+	// The interval, in seconds, at which we will run each check. If you want consistent
+	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
+	// Defaults to 10s for normal checks and 2s for others.
+	a.setCheckInterval(ns, "container", "container")
+	a.setCheckInterval(ns, "container_realtime", "rtcontainer")
+	a.setCheckInterval(ns, "process", "process")
+	a.setCheckInterval(ns, "process_realtime", "rtprocess")
+	a.setCheckInterval(ns, "connections", "connections")
+
+	// A list of regex patterns that will exclude a process if matched.
+	for _, b := range config.Datadog.GetStringSlice(key(ns, "blacklist_patterns")) {
+		r, err := regexp.Compile(b)
+		if err != nil {
+			log.Warnf("Ignoring invalid blacklist pattern: %s", b)
+		}
+		a.Blacklist = append(a.Blacklist, r)
+	}
+
+	// Enable/Disable the DataScrubber to obfuscate process args
+	if scrubArgsKey := key(ns, "scrub_args"); config.Datadog.IsSet(scrubArgsKey) {
+		a.Scrubber.Enabled = config.Datadog.GetBool(scrubArgsKey)
+	}
+
+	// A custom word list to enhance the default one used by the DataScrubber
+	a.Scrubber.AddCustomSensitiveWords(config.Datadog.GetStringSlice(key(ns, "custom_sensitive_words")))
+
+	// Strips all process arguments
+	if config.Datadog.GetBool(key(ns, "strip_proc_arguments")) {
+		a.Scrubber.StripAllArguments = true
+	}
+
+	// How many check results to buffer in memory when POST fails. The default is usually fine.
+	if queueSize := config.Datadog.GetInt(key(ns, "queue_size")); queueSize > 0 {
+		a.QueueSize = queueSize
+	}
+
+	// The maximum number of file descriptors to open when collecting net connections.
+	// Only change if you are running out of file descriptors from the Agent.
+	if maxProcFDs := config.Datadog.GetInt(key(ns, "max_proc_fds")); maxProcFDs > 0 {
+		a.MaxProcFDs = maxProcFDs
+	}
+
+	// The maximum number of processes, or containers per message. Note: Only change if the defaults are causing issues.
+	if maxPerMessage := config.Datadog.GetInt(key(ns, "max_per_message")); maxPerMessage > 0 {
+		if maxPerMessage <= maxPerMessage {
+			a.MaxPerMessage = maxPerMessage
+		} else {
+			log.Warn("Overriding the configured item count per message limit because it exceeds maximum")
+		}
+	}
+
+	// Overrides the path to the Agent bin used for getting the hostname. The default is usually fine.
+	a.DDAgentBin = defaultDDAgentBin
+	if agentBin := config.Datadog.GetString(key(ns, "dd_agent_bin")); agentBin != "" {
+		a.DDAgentBin = agentBin
+	}
+
+	// Windows: Sets windows process table refresh rate (in number of check runs)
+	if argRefresh := config.Datadog.GetInt(key(ns, "windows", "args_refresh_interval")); argRefresh != 0 {
+		a.Windows.ArgsRefreshInterval = argRefresh
+	}
+
+	// Windows: Controls getting process arguments immediately when a new process is discovered
+	if addArgsKey := key(ns, "windows", "add_new_args"); config.Datadog.IsSet(addArgsKey) {
+		a.Windows.AddNewArgs = config.Datadog.GetBool(addArgsKey)
+	}
+
+	// Optional additional pairs of endpoint_url => []apiKeys to submit to other locations.
+	for endpointURL, apiKeys := range config.Datadog.GetStringMapStringSlice(key(ns, "additional_endpoints")) {
+		u, err := URL.Parse(endpointURL)
+		if err != nil {
+			return fmt.Errorf("invalid additional endpoint url '%s': %s", endpointURL, err)
+		}
+		for _, k := range apiKeys {
+			a.APIEndpoints = append(a.APIEndpoints, APIEndpoint{
+				APIKey:   k,
+				Endpoint: u,
+			})
+		}
+	}
+
+	// Pull additional parameters from the global config file.
+	a.LogLevel = config.Datadog.GetString("log_level")
+	a.StatsdPort = config.Datadog.GetInt("dogstatsd_port")
+	a.Transport = ddutil.CreateHTTPTransport()
 
 	return nil
+}
+
+func (a *AgentConfig) setCheckInterval(ns, check, checkKey string) {
+	if interval := config.Datadog.GetInt(key(ns, "intervals", check)); interval != 0 {
+		log.Infof("Overriding container check interval to %ds", interval)
+		a.CheckIntervals[checkKey] = time.Duration(interval) * time.Second
+	}
 }


### PR DESCRIPTION
This PR is just part 1 of a series. First step is updating the processes YAML config.

- Use the new common config utility package: `github.com/DataDog/datadog-agent/pkg/config`
- Tests were updated to use resource files for example YAML configuration files.