### PR TITLE
Network tracer should skip local DNS connections by default + fix pprof endpoint panic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ type AgentConfig struct {
 	DisableTCPTracing        bool
 	DisableUDPTracing        bool
 	DisableIPv6Tracing       bool
+	CollectLocalDNS          bool
 	NetworkTracerSocketPath  string
 	NetworkTracerLogFile     string
 	MaxTrackedConnections    uint

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -33,6 +33,10 @@ func TracerConfigFromConfig(cfg *AgentConfig) *ebpf.Config {
 		log.Info("network tracer TCP tracing disabled by configuration")
 	}
 
+	if cfg.CollectLocalDNS {
+		tracerConfig.CollectLocalDNS = true
+	}
+
 	tracerConfig.MaxTrackedConnections = cfg.MaxTrackedConnections
 	tracerConfig.ProcRoot = getProcRoot()
 

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -37,6 +37,8 @@ func (a *AgentConfig) loadNetworkYamlConfig(path string) error {
 	a.DisableUDPTracing = config.Datadog.GetBool(key(netNS, "disable_udp"))
 	a.DisableIPv6Tracing = config.Datadog.GetBool(key(netNS, "disable_ipv6"))
 
+	a.CollectLocalDNS = config.Datadog.GetBool(key(netNS, "collect_local_dns"))
+
 	// Whether agent should expose profiling endpoints over the unix socket
 	a.EnableDebugProfiling = config.Datadog.GetBool(key(netNS, "debug_profiling_enabled"))
 

--- a/ebpf/config.go
+++ b/ebpf/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	// CollectIPv6Conns specifics whether the tracer should capture traffic for IPv6 TCP/UDP connections
 	CollectIPv6Conns bool
 
+	// CollectLocalDNS specifies whether the tracer should capture traffic for local DNS calls
+	CollectLocalDNS bool
+
 	// UDPConnTimeout determines the length of traffic inactivity between two (IP, port)-pairs before declaring a UDP
 	// connection as inactive.
 	// Note: As UDP traffic is technically "connection-less", for tracking, we consider a UDP connection to be traffic
@@ -39,6 +42,7 @@ func NewDefaultConfig() *Config {
 		CollectTCPConns:       true,
 		CollectUDPConns:       true,
 		CollectIPv6Conns:      true,
+		CollectLocalDNS:       false,
 		UDPConnTimeout:        30 * time.Second,
 		TCPConnTimeout:        10 * time.Minute,
 		MaxTrackedConnections: 65536,

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -36,7 +36,7 @@ type NetworkState interface {
 	RemoveClient(clientID string)
 
 	// GetStats returns a map of statistics about the current network state
-	GetStats(closedPollingLost, closedPollingReceived uint64) map[string]interface{}
+	GetStats(closedPollLost, closedPollReceived, tracerSkippedCount uint64) map[string]interface{}
 }
 
 type telemetry struct {
@@ -350,7 +350,7 @@ func (ns *networkState) removeExpiredStats(c *client, latestTimeEpoch uint64) in
 }
 
 // GetStats returns a map of statistics about the current network state
-func (ns *networkState) GetStats(closedPollingLost, closedPollingReceived uint64) map[string]interface{} {
+func (ns *networkState) GetStats(closedPollLost, closedPollReceived, tracerSkipped uint64) map[string]interface{} {
 	ns.Lock()
 	defer ns.Unlock()
 
@@ -370,8 +370,9 @@ func (ns *networkState) GetStats(closedPollingLost, closedPollingReceived uint64
 			"unordered_conns":              ns.telemetry.unorderedConns,
 			"closed_conn_dropped":          ns.telemetry.closedConnDropped,
 			"conn_dropped":                 ns.telemetry.connDropped,
-			"closed_conn_polling_lost":     int(closedPollingLost),
-			"closed_conn_polling_received": int(closedPollingReceived),
+			"closed_conn_polling_lost":     int(closedPollLost),
+			"closed_conn_polling_received": int(closedPollReceived),
+			"tracer_conns_skipped":         int(tracerSkipped), // Skipped connections (e.g. Local DNS requests)
 		},
 		"current_time":       time.Now().Unix(),
 		"latest_bpf_time_ns": ns.latestTimeEpoch,


### PR DESCRIPTION
Looking at some nodes with higher connection counts, I noticed that a large number of connections were DNS traffic on the local host. I think it's important to capture external DNS traffic, but we can probably get away with disregarding the noisy local traffic.

This PR modifies the network-tracer to do this by default.

**Example node (Capture over 30s):**
- Before: 21014 unique connections
- After: 7720 unique connections

We also fix a bug around disabling pprof on the network-tracer.

@DataDog/burrito 