### PR TITLE
[wip] Agent side connection aggregation for common static ports

### DIFF
--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -280,7 +280,7 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 func commonPorts(m map[uint16]int) map[uint16]struct{} {
 	ports := make(map[uint16]struct{})
 	for p, count := range m {
-		if count > 100 { // TODO: Make configurable
+		if count > 25 { // TODO: Make configurable
 			ports[p] = struct{}{}
 		}
 	}

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -142,7 +142,7 @@ func (ns *networkState) Connections(id string, latestTime uint64, latestConns []
 	// Flush closed connection map
 	ns.clients[id].closedConnections = map[string]ConnectionStats{}
 
-	return conns
+	return aggregateConnections(conns)
 }
 
 // getConnsByKey returns a mapping of byte-key -> connection for easier access + manipulation

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -2,6 +2,8 @@ package ebpf
 
 import (
 	"bytes"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -273,6 +275,102 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 	}
 
 	return conns
+}
+
+func commonPorts(m map[uint16]int) map[uint16]struct{} {
+	ports := make(map[uint16]struct{})
+	for p, count := range m {
+		if count > 100 { // TODO: Make configurable
+			ports[p] = struct{}{}
+		}
+	}
+	return ports
+}
+
+func aggregateConnections(conns []ConnectionStats) []ConnectionStats {
+	aggrConns := make([]ConnectionStats, 0)
+
+	sort.Slice(conns, func(i, j int) bool {
+		if conns[i].Pid < conns[j].Pid { // Sort first by PID
+			return true
+		} else if conns[i].Pid == conns[j].Pid { // Then by destination IP
+			if comp := strings.Compare(conns[i].Dest, conns[j].Dest); comp == -1 {
+				return true
+			} else if comp == 0 { // Then by source IP
+				return strings.Compare(conns[i].Source, conns[j].Source) == -1
+			}
+		}
+		return false
+	})
+
+	// Go over PID sub-ranges
+	applyFuncOnRange(conns,
+		func(a, b *ConnectionStats) bool {
+			return a.Pid == b.Pid
+		},
+		func(pidRange []ConnectionStats) {
+			// Find common ports for this PID range
+			staticSource, staticDest := map[uint16]int{}, map[uint16]int{}
+			for _, c := range pidRange {
+				staticDest[c.DPort]++
+				staticSource[c.SPort]++
+			}
+			commonSource, commonDest := commonPorts(staticSource), commonPorts(staticDest)
+
+			// Go over IP sub-ranges and aggregate
+			applyFuncOnRange(pidRange,
+				func(a, b *ConnectionStats) bool {
+					return a.Source == b.Source && a.Dest == b.Dest
+				},
+				func(ipRange []ConnectionStats) {
+					aggrConns = append(aggrConns, aggIPRange(ipRange, commonSource, commonDest)...)
+				},
+			)
+		},
+	)
+
+	return aggrConns
+}
+
+func aggIPRange(conns []ConnectionStats, staticSources, staticDests map[uint16]struct{}) []ConnectionStats {
+	source, dest := map[uint16]int{}, map[uint16]int{}
+	aggrConns := make([]ConnectionStats, 0)
+
+	for _, c := range conns {
+		if _, ok := staticSources[c.SPort]; ok {
+			if idx, ok := source[c.SPort]; ok {
+				aggregate(aggrConns, idx, c)
+			} else {
+				c.DPort = 0
+				c.RollUpCount++
+				aggrConns = append(aggrConns, c)
+				source[c.SPort] = len(aggrConns) - 1
+			}
+		} else if _, ok := staticDests[c.DPort]; ok {
+			if idx, ok := dest[c.DPort]; ok {
+				aggregate(aggrConns, idx, c)
+			} else {
+				c.SPort = 0
+				c.RollUpCount++
+				aggrConns = append(aggrConns, c)
+				dest[c.DPort] = len(aggrConns) - 1
+			}
+		} else {
+			aggrConns = append(aggrConns, c)
+		}
+	}
+
+	return aggrConns
+}
+
+func aggregate(aggrConns []ConnectionStats, idx int, c ConnectionStats) {
+	aggrConns[idx].LastSentBytes += c.LastSentBytes
+	aggrConns[idx].LastRecvBytes += c.LastRecvBytes
+	aggrConns[idx].LastRetransmits += c.LastRetransmits
+	aggrConns[idx].MonotonicSentBytes += c.MonotonicSentBytes
+	aggrConns[idx].MonotonicRecvBytes += c.MonotonicRecvBytes
+	aggrConns[idx].MonotonicRetransmits += c.MonotonicRetransmits
+	aggrConns[idx].RollUpCount++
 }
 
 func (ns *networkState) updateConnWithStats(client *client, key string, c *ConnectionStats, now time.Time) {

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -14,6 +14,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TODO: Tests
+
+//func BenchmarkSortAndAggregateConnections(b *testing.B) {
+//	jsonFile, err := os.Open("./testdata/connections2.json")
+//	assert.NoError(b, err)
+//	defer jsonFile.Close()
+//
+//	buf, err := ioutil.ReadAll(jsonFile)
+//	assert.NoError(b, err)
+//
+//	connections := Connections{}
+//	err = connections.UnmarshalJSON(buf)
+//	assert.NoError(b, err)
+//
+//	b.ResetTimer()
+//	b.ReportAllocs()
+//
+//	for i := 0; i < b.N; i++ {
+//		aggregateConnections(connections.Conns)
+//	}
+//}
+//
+//func TestSortAndAggregateConnections(t *testing.T) {
+//	jsonFile, err := os.Open("./testdata/connections2.json")
+//	assert.NoError(t, err)
+//	defer jsonFile.Close()
+//
+//	buf, err := ioutil.ReadAll(jsonFile)
+//	assert.NoError(t, err)
+//
+//	connections := Connections{}
+//	err = connections.UnmarshalJSON(buf)
+//	assert.NoError(t, err)
+//
+//	aggregateConnections(connections.Conns)
+//
+//	//assert.Error(t, nil)
+//}
+
 func BenchmarkStoreClosedConnection(b *testing.B) {
 	conns := generateRandConnections(30000)
 	for _, bench := range []struct {


### PR DESCRIPTION
On a node with many connections, this took us from 7744 connections to 1778.

Downside is that the monotonic counters are currently not correct, and on the backend, any level of aggregation will not provide a correct rollup count.

We may want to keep the sorting logic & create + send through a map of pid -> common static source/dest ports for use on the backend instead.