### PR TITLE
Connection direction should be set for short lived connections

### DIFF
--- a/ebpf/tracer_test.go
+++ b/ebpf/tracer_test.go
@@ -324,6 +324,7 @@ func TestTCPShortlived(t *testing.T) {
 	assert.Equal(t, 0, int(conn.MonotonicRetransmits))
 	assert.Equal(t, os.Getpid(), int(conn.Pid))
 	assert.Equal(t, addrPort(server.address), int(conn.DPort))
+	assert.Equal(t, LOCAL, conn.Direction)
 
 	// Confirm that the connection has been cleaned up since the last get
 	connections = getConnections(t, tr)


### PR DESCRIPTION
What it says on the tin. 

Short lived connections did not have the _direction_ set and were thus showing as _incoming_ (as the incoming constant has the 0 value on the ebpf side)