### PR TITLE
[network-tracer] Fix underflows

### DIFF
--- a/ebpf/event.go
+++ b/ebpf/event.go
@@ -60,7 +60,7 @@ __u32 retransmits;
 type TCPStats C.tcp_stats_t
 
 func (cs *ConnStatsWithTimestamp) isExpired(latestTime uint64, timeout uint64) bool {
-	return latestTime-uint64(cs.timestamp) > timeout
+	return latestTime > timeout+uint64(cs.timestamp)
 }
 
 func connStats(t *ConnTuple, s *ConnStatsWithTimestamp, tcpStats *TCPStats) ConnectionStats {

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -826,6 +827,5 @@ func generateRandConnections(n int) []ConnectionStats {
 var latestTime uint64 = 0
 
 func latestEpochTime() uint64 {
-	latestTime++
-	return latestTime
+	return atomic.AddUint64(&latestTime, 1)
 }

--- a/ebpf/tracer_test.go
+++ b/ebpf/tracer_test.go
@@ -628,6 +628,34 @@ func TestTooSmallBPFMap(t *testing.T) {
 	doneChan <- struct{}{}
 }
 
+func TestIsExpired(t *testing.T) {
+	// 10mn
+	var timeout uint64 = 600000000000
+	for _, tc := range []struct {
+		stats      ConnStatsWithTimestamp
+		latestTime uint64
+		expected   bool
+	}{
+		{
+			ConnStatsWithTimestamp{timestamp: 101},
+			100,
+			false,
+		},
+		{
+			ConnStatsWithTimestamp{timestamp: 100},
+			101,
+			false,
+		},
+		{
+			ConnStatsWithTimestamp{timestamp: 100},
+			101 + timeout,
+			true,
+		},
+	} {
+		assert.Equal(t, tc.expected, tc.stats.isExpired(tc.latestTime, timeout))
+	}
+}
+
 func findConnection(l, r net.Addr, c *Connections) (*ConnectionStats, bool) {
 	for _, conn := range c.Conns {
 		if addrMatches(l, conn.Source, conn.SPort) && addrMatches(r, conn.Dest, conn.DPort) {


### PR DESCRIPTION
This removes substractions in isExpired to avoid having a negative uint64 hence wrapping and returning a wrong result.

This resulted in considering some connections as expired while they were not like:

```
get connections !
active conn [TCP] [PID: 20329] [127.0.0.1:41064 ⇄ 127.0.0.1:45938] (local) 1280101 bytes sent (+0), 573 bytes received (+0), 0 retransmits (+0)
get connections !
active conn [TCP] [PID: 20329] [127.0.0.1:41064 ⇄ 127.0.0.1:45938] (local) 1280101 bytes sent (+0), 573 bytes received (+0), 0 retransmits (+0)
get connections !
active conn [TCP] [PID: 20329] [127.0.0.1:41064 ⇄ 127.0.0.1:45938] (local) 1280101 bytes sent (+0), 573 bytes received (+0), 0 retransmits (+0)
get connections !
active conn [TCP] [PID: 20329] [127.0.0.1:41064 ⇄ 127.0.0.1:45938] (local) 1601310 bytes sent (+0), 622 bytes received (+0), 0 retransmits (+0)
get connections !
active conn [TCP] [PID: 20329] [127.0.0.1:41064 ⇄ 127.0.0.1:45938] (local) 1601310 bytes sent (+0), 622 bytes received (+0), 0 retransmits (+0)
get connections !
expired conn: &{saddr_h:0 saddr_l:16777343 daddr_h:0 daddr_l:16777343 sport:41064 dport:45938 netns:4026531957 pid:20329 metadata:1}

get connections !
active conn [TCP] [PID: 20329] [127.0.0.1:41064 ⇄ 127.0.0.1:45938] (local) 753528 bytes sent (+0), 782 bytes received (+0), 0 retransmits (+0)
Underflow occured ! stats: {totalSent:1601310 totalRecv:622 totalRetransmits:0 lastUpdateEpoch:585516629226535}, conn: [TCP] [PID: 20329] [127.0.0.1:41064 ⇄ 127.0.0.1:45938] (local) 753528 bytes sent (+0), 782 bytes received (+0), 0 retransmits (+0)
```