### PR TITLE
Add secrets build tag to process-agent on unix

### DIFF
--- a/gorake.rb
+++ b/gorake.rb
@@ -41,11 +41,18 @@ def go_build(program, opts={})
   cmd = opts[:cmd]
   cmd += ' -race' if opts[:race]
   if os != "windows"
-    tag_set = 'docker kubelet kubeapiserver' # Default tags for non-windows OSes (e.g. linux)
-    tag_set += ' linux_bpf' if opts[:bpf]    # Add BPF if ebpf exists
-    tag_set += ' netgo' if opts[:bpf] && opts[:static]
+    # Default tags for non-windows OSes (e.g. linux)
+    tag_set = 'docker kubelet kubeapiserver secrets'
+
+    # Add BPF tags if enabled
+    if opts[:bpf]
+	  tag_set += ' linux_bpf'
+	  tag_set += ' netgo' if opts[:static]
+    end
+
     cmd += " -tags \'#{tag_set}\'"
   end
+
   print "cmd"
 
   # NOTE: We currently have issues running eBPF components in statically linked binaries, so in the meantime,


### PR DESCRIPTION
Adding the `secrets` build tag to our agent on unix.

Examples of tag being added on the [core agent](https://github.com/DataDog/datadog-agent/blob/db/ddau-610/tasks/build_tags.py#L30), and [trace agent](https://github.com/DataDog/datadog-agent/pull/3170)

@DataDog/burrito 