### PR TITLE
Accept different return path from `GetProgramDataDir()`.  Underlying

### DIFF
--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -38,9 +38,9 @@ func init() {
 	fmt.Printf("main_windows.init()")
 	pd, err := winutil.GetProgramDataDir()
 	if err == nil {
-		defaultConfigPath = filepath.Join(pd, "Datadog", "datadog.yaml")
-		defaultConfdPath = filepath.Join(pd, "Datadog", "conf.d")
-		defaultLogFilePath = filepath.Join(pd, "Datadog", "logs", "process.log")
+		defaultConfigPath = filepath.Join(pd, "datadog.yaml")
+		defaultConfdPath = filepath.Join(pd, "conf.d")
+		defaultLogFilePath = filepath.Join(pd, "logs", "process.log")
 	}
 }
 


### PR DESCRIPTION
implementation was changed to be the root of the config path
(programdata\datadog) by default, to allow for changing the config path
at install time.  Amend the return value accordingly, and update the
commit hash from `datadog-agent`