### PR TITLE
Fix config default not-set warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ vendor/
 vendor.orig/
 
 tracer-ebpf.o
+tracer-ebpf-debug.o
+
 .DS_Store
 .idea
 .vscode


### PR DESCRIPTION
Similar to traces, we're seeing trace errors for configuration gets without default values.

This should clear those up.

e.g.
```
2019-04-08 11:43:23 UTC | TRACE | WARN | (pkg/util/log/log.go:482 in func1) | failed to get configuration value for key "apm_config.additional_endpoints": unable to cast <nil> of type <nil> to map[string][]string
2019-04-08 11:43:23 UTC | TRACE | WARN | (pkg/util/log/log.go:482 in func1) | failed to get configuration value for key "proxy.no_proxy": unable to cast <nil> of type <nil> to []string
```