### PR TITLE
Make process_config.expvar configurable

### DIFF
--- a/cmd/agent/main_common.go
+++ b/cmd/agent/main_common.go
@@ -154,7 +154,7 @@ func runAgent(exit chan bool) {
 
 	if opts.info {
 		// using the debug port to get info to work
-		url := "http://localhost:6062/debug/vars"
+		url := fmt.Sprintf("http://localhost:%d/debug/vars", cfg.ProcessExpVarPort)
 		if err := Info(os.Stdout, cfg, url); err != nil {
 			os.Exit(1)
 		}
@@ -163,7 +163,7 @@ func runAgent(exit chan bool) {
 
 	// Run a profile server.
 	go func() {
-		http.ListenAndServe("localhost:6062", nil)
+		http.ListenAndServe(fmt.Sprintf("localhost:%d", cfg.ProcessExpVarPort), nil)
 	}()
 
 	cl, err := NewCollector(cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ type AgentConfig struct {
 	DDAgentBin         string
 	StatsdHost         string
 	StatsdPort         int
+	ProcessExpVarPort  int
 
 	// Network collection configuration
 	EnableNetworkTracing     bool
@@ -156,6 +157,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		AllowRealTime:      true,
 		HostName:           "",
 		Transport:          NewDefaultTransport(),
+		ProcessExpVarPort:  6062,
 
 		// Statsd for internal instrumentation
 		StatsdHost: "127.0.0.1",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -165,6 +165,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(os.Getenv("HOST_SYS"), "")
 	os.Setenv("DOCKER_DD_AGENT", "no")
 	assert.Equal(containerChecks, agentConfig.EnabledChecks)
+	assert.Equal(6062, agentConfig.ProcessExpVarPort)
 
 	os.Unsetenv("DOCKER_DD_AGENT")
 }
@@ -263,6 +264,7 @@ func TestAgentConfigYamlAndNetworkConfig(t *testing.T) {
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
+	assert.Equal(5065, agentConfig.ProcessExpVarPort)
 
 	agentConfig, err = NewAgentConfig(
 		"test",

--- a/config/testdata/TestDDAgentConfigYamlAndNetworkConfig.yaml
+++ b/config/testdata/TestDDAgentConfigYamlAndNetworkConfig.yaml
@@ -12,3 +12,4 @@ process_config:
     args_refresh_interval: 100
     add_new_args: false
   scrub_args: false
+  expvar_port: 5065

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"net/url"
 	"regexp"
 	"strings"
@@ -140,6 +141,14 @@ func (a *AgentConfig) loadProcessYamlConfig(path string) error {
 			}
 			a.Blacklist = append(a.Blacklist, r)
 		}
+	}
+
+	if k := key(ns, "expvar_port"); config.Datadog.IsSet(k) {
+		port := config.Datadog.GetInt(k)
+		if port <= 0 {
+			return errors.Errorf("invalid %s -- %d", k, port)
+		}
+		a.ProcessExpVarPort = port
 	}
 
 	// Enable/Disable the DataScrubber to obfuscate process args


### PR DESCRIPTION
Adds a flag, similar to that of the core agent: `procss_agent.expvar_port` which describes where the default HTTP handler will bind.  

Fixes the process-agent side of #292 