### PR TITLE
Remove allocations in ByteKey.  Pre-allocate size for connections slice in mergeConnections

### DIFF
--- a/ebpf/event_common.go
+++ b/ebpf/event_common.go
@@ -117,7 +117,11 @@ func (c ConnectionStats) ByteKey(buffer *bytes.Buffer) ([]byte, error) {
 	// Byte-packing to improve creation speed
 	// PID (32 bits) + SPort (16 bits) + DPort (16 bits) = 64 bits
 	p0 := uint64(c.Pid)<<32 | uint64(c.SPort)<<16 | uint64(c.DPort)
-	if err := binary.Write(buffer, binary.LittleEndian, p0); err != nil {
+
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], p0)
+
+	if _, err := buffer.Write(buf[:]); err != nil {
 		return nil, err
 	}
 	if _, err := buffer.WriteString(c.Source); err != nil {
@@ -125,7 +129,7 @@ func (c ConnectionStats) ByteKey(buffer *bytes.Buffer) ([]byte, error) {
 	}
 	// Family (4 bits) + Type (4 bits) = 8 bits
 	p1 := uint8(c.Family)<<4 | uint8(c.Type)
-	if err := binary.Write(buffer, binary.LittleEndian, p1); err != nil {
+	if err := buffer.WriteByte(p1); err != nil {
 		return nil, err
 	}
 	if _, err := buffer.WriteString(c.Dest); err != nil {

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -211,7 +211,7 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 	client := ns.clients[id]
 	client.lastFetch = now
 
-	conns := make([]ConnectionStats, 0)
+	conns := make([]ConnectionStats, 0, len(active)+len(client.closedConnections))
 
 	// Closed connections
 	for key, closedConn := range client.closedConnections {


### PR DESCRIPTION
@DataDog/burrito 

Saw `mergeConnections` as a large source of allocations.  Pre-allocating the list should help reduce that.

I also removed some low hanging fruit in `ByteKey`

```
BenchmarkOldByteKey-2   	20000000	        81.0 ns/op	      24 B/op	       3 allocs/op
BenchmarkNewByteKey-2   	50000000	        24.8 ns/op	       0 B/op	       0 allocs/op
```