### PR TITLE
Use a re-usable buffer for appending active connections

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1014,6 +1014,7 @@
     "github.com/mailru/easyjson",
     "github.com/mailru/easyjson/jlexer",
     "github.com/mailru/easyjson/jwriter",
+    "github.com/pkg/errors",
     "github.com/shirou/w32",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",

--- a/ebpf/event_common.go
+++ b/ebpf/event_common.go
@@ -66,21 +66,12 @@ type Connections struct {
 	Conns []ConnectionStats `json:"connections"`
 }
 
-// ConnectionStats stores statistics for a single connection
+// ConnectionStats stores statistics for a single connection.  Field order in the struct should be 8-byte aligned
 //easyjson:json
 type ConnectionStats struct {
-	Pid    uint32           `json:"pid"`
-	Type   ConnectionType   `json:"type"`
-	Family ConnectionFamily `json:"family"`
-	NetNS  uint32           `json:"net_ns"`
-
 	// Source & Dest represented as a string to handle both IPv4 & IPv6
 	Source string `json:"source"`
 	Dest   string `json:"dest"`
-	SPort  uint16 `json:"sport"`
-	DPort  uint16 `json:"dport"`
-
-	Direction ConnectionDirection `json:"direction"`
 
 	MonotonicSentBytes uint64 `json:"monotonic_sent_bytes"`
 	LastSentBytes      uint64 `json:"last_sent_bytes"`
@@ -88,11 +79,20 @@ type ConnectionStats struct {
 	MonotonicRecvBytes uint64 `json:"monotonic_recv_bytes"`
 	LastRecvBytes      uint64 `json:"last_recv_bytes"`
 
+	// Last time the stats for this connection were updated
+	LastUpdateEpoch uint64 `json:"last_update_epoch"`
+
 	MonotonicRetransmits uint32 `json:"monotonic_retransmits"`
 	LastRetransmits      uint32 `json:"last_retransmits"`
 
-	// Last time the stats for this connection were updated
-	LastUpdateEpoch uint64 `json:"last_update_epoch"`
+	Pid   uint32 `json:"pid"`
+	NetNS uint32 `json:"net_ns"`
+
+	SPort     uint16              `json:"sport"`
+	DPort     uint16              `json:"dport"`
+	Type      ConnectionType      `json:"type"`
+	Family    ConnectionFamily    `json:"family"`
+	Direction ConnectionDirection `json:"direction"`
 }
 
 func (c ConnectionStats) String() string {

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -162,7 +162,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*Connections, error) {
 	t.bufferLock.Lock()
 	defer t.bufferLock.Unlock()
 
-	latestConns, latestTime, err := t.appendActiveConnections(t.buffer[:0])
+	latestConns, latestTime, err := t.getConnections(t.buffer[:0])
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving connections: %s", err)
 	}
@@ -177,7 +177,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*Connections, error) {
 	return &Connections{Conns: t.state.Connections(clientID, latestTime, latestConns)}, nil
 }
 
-func (t *Tracer) appendActiveConnections(active []ConnectionStats) ([]ConnectionStats, uint64, error) {
+func (t *Tracer) getConnections(active []ConnectionStats) ([]ConnectionStats, uint64, error) {
 	mp, err := t.getMap(connMap)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error retrieving the bpf %s map: %s", connMap, err)
@@ -348,7 +348,7 @@ func (t *Tracer) DebugNetworkState(clientID string) (map[string]interface{}, err
 
 // DebugNetworkMaps returns all connections stored in the BPF maps without modifications from network state
 func (t *Tracer) DebugNetworkMaps() (*Connections, error) {
-	latestConns, _, err := t.appendActiveConnections(make([]ConnectionStats, 0))
+	latestConns, _, err := t.getConnections(make([]ConnectionStats, 0))
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving connections: %s", err)
 	}

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -177,6 +177,8 @@ func (t *Tracer) GetActiveConnections(clientID string) (*Connections, error) {
 	return &Connections{Conns: t.state.Connections(clientID, latestTime, latestConns)}, nil
 }
 
+// getConnections returns all of the active connections in the ebpf maps along with the latest timestamp.  It takes
+// a reusable buffer for appending the active connections so that this doesn't continuously allocate
 func (t *Tracer) getConnections(active []ConnectionStats) ([]ConnectionStats, uint64, error) {
 	mp, err := t.getMap(connMap)
 	if err != nil {

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -29,6 +30,9 @@ type Tracer struct {
 	perfReceived uint64
 	perfLost     uint64
 	skippedConns uint64
+
+	buffer     []ConnectionStats
+	bufferLock sync.Mutex
 }
 
 // maxActive configures the maximum number of instances of the kretprobe-probed functions handled simultaneously.
@@ -82,6 +86,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 		state:          NewDefaultNetworkState(),
 		portMapping:    portMapping,
 		localAddresses: localAddresses,
+		buffer:         make([]ConnectionStats, 0, 512),
 	}
 
 	tr.perfMap, err = tr.initPerfPolling()
@@ -154,15 +159,25 @@ func (t *Tracer) Stop() {
 }
 
 func (t *Tracer) GetActiveConnections(clientID string) (*Connections, error) {
-	latestConns, latestTime, err := t.getConnections()
+	t.bufferLock.Lock()
+	defer t.bufferLock.Unlock()
+
+	latestConns, latestTime, err := t.appendActiveConnections(t.buffer[:0])
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving connections: %s", err)
+	}
+
+	// Grow or shrink buffer depending on the usage
+	if len(latestConns) >= cap(t.buffer)*2 {
+		t.buffer = make([]ConnectionStats, 0, cap(t.buffer)*2)
+	} else if len(latestConns) <= cap(t.buffer)/2 {
+		t.buffer = make([]ConnectionStats, 0, cap(t.buffer)/2)
 	}
 
 	return &Connections{Conns: t.state.Connections(clientID, latestTime, latestConns)}, nil
 }
 
-func (t *Tracer) getConnections() ([]ConnectionStats, uint64, error) {
+func (t *Tracer) appendActiveConnections(active []ConnectionStats) ([]ConnectionStats, uint64, error) {
 	mp, err := t.getMap(connMap)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error retrieving the bpf %s map: %s", connMap, err)
@@ -194,8 +209,7 @@ func (t *Tracer) getConnections() ([]ConnectionStats, uint64, error) {
 
 	// Iterate through all key-value pairs in map
 	key, nextKey, stats := &ConnTuple{}, &ConnTuple{}, &ConnStatsWithTimestamp{}
-	active := make([]ConnectionStats, 0)
-	expired := make([]*ConnTuple, 0)
+	var expired []*ConnTuple
 	for {
 		hasNext, _ := t.m.LookupNextElement(mp, unsafe.Pointer(key), unsafe.Pointer(nextKey), unsafe.Pointer(stats))
 		if !hasNext {
@@ -231,7 +245,7 @@ func (t *Tracer) removeEntries(mp, tcpMp *bpflib.Map, entries []*ConnTuple) {
 		err := t.m.DeleteElement(mp, unsafe.Pointer(entries[i]))
 		if err != nil {
 			// It's possible some other process deleted this entry already (e.g. tcp_close)
-			log.Warnf("failed to remove entry from connections map: %s", err)
+			_ = log.Warnf("failed to remove entry from connections map: %s", err)
 		}
 
 		// We have to remove the PID to remove the element from the TCP Map since we don't use the pid there
@@ -248,7 +262,13 @@ func (t *Tracer) getTCPStats(mp *bpflib.Map, tuple *ConnTuple) *TCPStats {
 	tuple.pid = 0
 
 	stats := &TCPStats{retransmits: 0}
-	_ = t.m.LookupElement(mp, unsafe.Pointer(tuple), unsafe.Pointer(stats))
+
+	// Don't bother looking in the map if the connection is UDP, there will never be data for that and we will avoid
+	// the overhead of the syscall and creating the resultant error
+	if connType(uint(tuple.metadata)) == TCP {
+		_ = t.m.LookupElement(mp, unsafe.Pointer(tuple), unsafe.Pointer(stats))
+	}
+
 	tuple.pid = pid
 
 	return stats
@@ -328,7 +348,7 @@ func (t *Tracer) DebugNetworkState(clientID string) (map[string]interface{}, err
 
 // DebugNetworkMaps returns all connections stored in the BPF maps without modifications from network state
 func (t *Tracer) DebugNetworkMaps() (*Connections, error) {
-	latestConns, _, err := t.getConnections()
+	latestConns, _, err := t.appendActiveConnections(make([]ConnectionStats, 0))
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving connections: %s", err)
 	}
@@ -388,7 +408,7 @@ func readLocalAddresses() map[string]struct{} {
 
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		log.Errorf("error reading network interfaces: %s", err)
+		_ = log.Errorf("error reading network interfaces: %s", err)
 		return addresses
 	}
 
@@ -396,7 +416,7 @@ func readLocalAddresses() map[string]struct{} {
 		addrs, err := intf.Addrs()
 
 		if err != nil {
-			log.Errorf("error reading interface %s addresses", intf.Name, err)
+			_ = log.Errorf("error reading interface %s addresses: %s", intf.Name, err)
 			continue
 		}
 


### PR DESCRIPTION
Profiling the tracer shows `getConnections` as the largest source of allocations, specifically building up the active connection list.  For hosts with a high number of connections, we continuously allocate (and grow) a large array every time.

This PR adds a reusable buffer in the tracer for appending the active connections to which coarsely grows or shrinks over time.

I also 8-byte aligned the `ConnectionStats` struct to save a whopping 8 bytes of memory

@DataDog/burrito 