### PR TITLE
[network-tracer] Fix underflows in state.removeExpiredStats

### DIFF
--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -354,7 +354,7 @@ func (ns *networkState) cleanupState(now time.Time, clearExpiredStats, flushStat
 func (ns *networkState) removeExpiredStats(c *client, latestTimeEpoch uint64) int {
 	expired := make([]string, 0)
 	for key, s := range c.stats {
-		if latestTimeEpoch-s.lastUpdateEpoch > uint64(ns.expiry.Nanoseconds()) {
+		if latestTimeEpoch > s.lastUpdateEpoch+uint64(ns.expiry.Nanoseconds()) {
 			expired = append(expired, key)
 		}
 	}

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -223,6 +223,12 @@ func (t *Tracer) getConnections() ([]ConnectionStats, uint64, error) {
 		_ = t.m.DeleteElement(portMp, unsafe.Pointer(&key))
 	}
 
+	// Get the latest time a second time because it could have changed while we were reading the eBPF map
+	latestTime, _, err = t.getLatestTimestamp()
+	if err != nil {
+		return nil, 0, fmt.Errorf("error retrieving latest timestamp: %s", err)
+	}
+
 	return active, latestTime, nil
 }
 


### PR DESCRIPTION
I noticed some underflows in `removeExpiredStats` (this could lead to wrong values stored in state)

This should fix it