### PR TITLE
Reduce TCP expiry time for connection tracking

### DIFF
--- a/ebpf/config.go
+++ b/ebpf/config.go
@@ -47,7 +47,7 @@ func NewDefaultConfig() *Config {
 		CollectIPv6Conns:      true,
 		CollectLocalDNS:       false,
 		UDPConnTimeout:        30 * time.Second,
-		TCPConnTimeout:        10 * time.Minute,
+		TCPConnTimeout:        2 * time.Minute,
 		MaxTrackedConnections: 65536,
 		ProcRoot:              "/proc",
 		BPFDebug:              false,

--- a/ebpf/event.go
+++ b/ebpf/event.go
@@ -47,6 +47,10 @@ func (t *ConnTuple) copy() *ConnTuple {
 	}
 }
 
+func (t *ConnTuple) isTCP() bool {
+	return connType(uint(t.metadata)) == TCP
+}
+
 /* conn_stats_ts_t
 __u64 sent_bytes;
 __u64 recv_bytes;

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -41,7 +41,7 @@ type NetworkState interface {
 	RemoveConnections(keys []string)
 
 	// GetStats returns a map of statistics about the current network state
-	GetStats(closedPollLost, closedPollReceived, tracerSkippedCount uint64) map[string]interface{}
+	GetStats(closedPollLost, closedPollReceived, tracerSkippedCount, expiredTCP uint64) map[string]interface{}
 
 	// DebugNetworkState returns a map with the current network state for a client ID
 	DumpState(clientID string) map[string]interface{}
@@ -340,7 +340,7 @@ func (ns *networkState) RemoveConnections(keys []string) {
 }
 
 // GetStats returns a map of statistics about the current network state
-func (ns *networkState) GetStats(closedPollLost, closedPollReceived, tracerSkipped uint64) map[string]interface{} {
+func (ns *networkState) GetStats(closedPollLost, closedPollReceived, tracerSkipped, expiredTCP uint64) map[string]interface{} {
 	ns.Lock()
 	defer ns.Unlock()
 
@@ -362,7 +362,8 @@ func (ns *networkState) GetStats(closedPollLost, closedPollReceived, tracerSkipp
 			"conn_dropped":                 ns.telemetry.connDropped,
 			"closed_conn_polling_lost":     int(closedPollLost),
 			"closed_conn_polling_received": int(closedPollReceived),
-			"tracer_conns_skipped":         int(tracerSkipped), // Skipped connections (e.g. Local DNS requests)
+			"ok_conns_skipped":             int(tracerSkipped), // Skipped connections (e.g. Local DNS requests)
+			"expired_tcp_conns":            int(expiredTCP),
 		},
 		"current_time":       time.Now().Unix(),
 		"latest_bpf_time_ns": ns.latestTimeEpoch,

--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -224,7 +224,7 @@ func (t *Tracer) getConnections(active []ConnectionStats) ([]ConnectionStats, ui
 			break
 		} else if stats.isExpired(latestTime, t.timeoutForConn(nextKey)) {
 			expired = append(expired, nextKey.copy())
-			if key.isTCP() {
+			if nextKey.isTCP() {
 				atomic.AddUint64(&t.expiredTCPConns, 1)
 			}
 		} else {


### PR DESCRIPTION
10 minutes is a long time to hold onto a dead connection, especially for nodes with high connection churn (e.g. load balancers).

We're still looking into the root cause of why we're missing `tcp_close` events occasionally on nodes, but this will help alleviate a lot of the memory pressure added.

On one node that we've tracked with high memory usage, this will bring down the stored connections from ~45k connections to ~10k.

The downside is that if we want to track live connections that are discarded by an application (e.g. leaked connections), we will only have two minutes worth of data on this.
- For now this is fine since we're not doing anything around leaked connection tracking. We can revisit once we've identified the bug.