### PR TITLE
[network-tracer] use human readable keys in dumps

### DIFF
--- a/ebpf/event_test.go
+++ b/ebpf/event_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -22,6 +23,27 @@ var (
 		MonotonicRecvBytes: 312312,
 	}
 )
+
+func TestBeautifyKey(t *testing.T) {
+	buf := &bytes.Buffer{}
+	for _, c := range []ConnectionStats{
+		testConn,
+		ConnectionStats{
+			Pid:    345,
+			Type:   0,
+			Family: 1,
+			Source: "127.0.0.1",
+			Dest:   "192.168.0.103",
+			SPort:  4444,
+			DPort:  8888,
+		},
+	} {
+		bk, err := c.ByteKey(buf)
+		require.NoError(t, err)
+		expected := fmt.Sprintf(keyFmt, c.Pid, c.Source, c.SPort, c.Dest, c.DPort, c.Family, c.Type)
+		assert.Equal(t, expected, BeautifyKey(string(bk)))
+	}
+}
 
 var sink string
 

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -377,7 +377,7 @@ func (ns *networkState) DumpState(clientID string) map[string]interface{} {
 	data := map[string]interface{}{}
 	if client, ok := ns.clients[clientID]; ok {
 		for connKey, s := range client.stats {
-			data[connKey] = map[string]uint64{
+			data[BeautifyKey(connKey)] = map[string]uint64{
 				"total_sent":        s.totalSent,
 				"total_recv":        s.totalRecv,
 				"total_retransmits": uint64(s.totalRetransmits),


### PR DESCRIPTION
Now:
```
p:345|src:127.0.0.1:4444|dst:192.168.0.103:8888|f:1|t:0
```

Before:
```
"\Y127.0.0.1||192.168.0.103
```