### PR TITLE
Use global net namespace for netlink if possible

### DIFF
--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -89,7 +89,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 
 	conntracker := netlink.NewNoOpConntracker()
 	if config.EnableConntrack {
-		if c, err := netlink.NewConntracker(config.ConntrackShortTermBufferSize); err != nil {
+		if c, err := netlink.NewConntracker(config.ProcRoot, config.ConntrackShortTermBufferSize); err != nil {
 			log.Warnf("could not initialize conntrack, tracer will continue without NAT tracking")
 		} else {
 			conntracker = c

--- a/netlink/conntracker.go
+++ b/netlink/conntracker.go
@@ -53,12 +53,14 @@ type realConntracker struct {
 }
 
 // NewConntracker creates a new conntracker with a short term buffer capped at the given size
-func NewConntracker(stbSize int) (Conntracker, error) {
+func NewConntracker(procRoot string, stbSize int) (Conntracker, error) {
 	if stbSize <= 0 {
 		return nil, fmt.Errorf("short term buffer size is less than 0")
 	}
 
-	nfct, err := ct.Open(&ct.Config{ReadTimeout: 10 * time.Millisecond})
+	netns := guessRootNetNSFd(procRoot)
+
+	nfct, err := ct.Open(&ct.Config{ReadTimeout: 10 * time.Millisecond, NetNS: netns})
 	if err != nil {
 		return nil, err
 	}

--- a/netlink/conntracker.go
+++ b/netlink/conntracker.go
@@ -58,7 +58,7 @@ func NewConntracker(procRoot string, stbSize int) (Conntracker, error) {
 		return nil, fmt.Errorf("short term buffer size is less than 0")
 	}
 
-	netns := guessRootNetNSFd(procRoot)
+	netns := getGlobalNetNSFD(procRoot)
 
 	nfct, err := ct.Open(&ct.Config{ReadTimeout: 10 * time.Millisecond, NetNS: netns})
 	if err != nil {

--- a/netlink/net_ns.go
+++ b/netlink/net_ns.go
@@ -8,21 +8,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// guessRootNetNSFd guesses the file descriptor of the root net NS
+// getGlobalNetNSFD guesses the file descriptor of the root net NS
 // and returns 0 in case of failure
-func guessRootNetNSFd(procRoot string) int {
-	for _, path := range []string{
-		procRoot + "/1/ns/net",
-		"/proc/1/ns/net",
-	} {
-		file, err := os.Open(path)
-		if err != nil {
-			log.Debugf("could not attach to net namespace at %s: %v", path, err)
-			continue
-		}
-
-		log.Debugf("attaching to net namespace at %s", path)
-		return int(file.Fd())
+func getGlobalNetNSFD(procRoot string) int {
+	path := procRoot + "/1/ns/net"
+	file, err := os.Open(path)
+	if err != nil {
+		log.Warnf("could not attach to net namespace at %s: %v", path, err)
+		return 0
 	}
-	return 0
+
+	log.Infof("attaching to net namespace at %s", path)
+	return int(file.Fd())
 }

--- a/netlink/net_ns.go
+++ b/netlink/net_ns.go
@@ -1,0 +1,28 @@
+//+build linux
+
+package netlink
+
+import (
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// guessRootNetNSFd guesses the file descriptor of the root net NS
+// and returns 0 in case of failure
+func guessRootNetNSFd(procRoot string) int {
+	for _, path := range []string{
+		procRoot + "/1/ns/net",
+		"/proc/1/ns/net",
+	} {
+		file, err := os.Open(path)
+		if err != nil {
+			log.Debugf("could not attach to net namespace at %s: %v", path, err)
+			continue
+		}
+
+		log.Debugf("attaching to net namespace at %s", path)
+		return int(file.Fd())
+	}
+	return 0
+}


### PR DESCRIPTION
When a netlink socket is created, messages for the current network
namespace are sent on the socket. This means that in a containernized
environment, we will by default get data for the containers network
namespace.

An easy workaround is to use `hostNetwork: true` when creating the
daemon. This isn't ideal.

This PR attempts to "find" the global namespace (which is reperesented
as a file descriptor) using the mounted host procfs and uses
go-conntrack's ability to temporarily change net namespace.

Requires the CAP_SYS_PTRACE capability, along with CAP_NET_ADMIN for
netlink.