### PR TITLE
network-tracer: Fix leaky stats objects that resulted in underflows

### DIFF
--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -141,7 +141,20 @@ func (ns *networkState) Connections(id string, latestTime uint64, latestConns []
 	// Update all connections with relevant up-to-date stats for client
 	conns := ns.mergeConnections(id, connsByKey)
 
-	// Flush closed connection map
+	// XXX: we should change the way we clean this map once
+	// https://github.com/golang/go/issues/20135 is solved
+	newStats := make(map[string]*stats, len(ns.clients[id].stats))
+	for key, st := range ns.clients[id].stats {
+		// Don't keep closed connections' stats
+		_, isClosed := ns.clients[id].closedConnections[key]
+		_, isActive := connsByKey[key]
+		if !isClosed || isActive {
+			newStats[key] = st
+		}
+	}
+	ns.clients[id].stats = newStats
+
+	// Flush closed connection map and stats
 	ns.clients[id].closedConnections = map[string]ConnectionStats{}
 
 	return conns
@@ -226,13 +239,9 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 			closedConn.MonotonicRetransmits += activeConn.MonotonicRetransmits
 
 			ns.createStatsForKey(client, key)
-			ns.updateConnWithStats(client, key, &closedConn)
+			ns.updateConnWithStatsAndActiveConn(client, key, *activeConn, &closedConn)
 		} else {
 			ns.updateConnWithStats(client, key, &closedConn)
-			// Since connection is no longer active, lets just remove the stats object afterwords
-			if _, ok := client.stats[key]; ok {
-				delete(client.stats, key)
-			}
 		}
 
 		conns = append(conns, closedConn)
@@ -265,6 +274,28 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 	}
 
 	return conns
+}
+
+func (ns *networkState) updateConnWithStatsAndActiveConn(client *client, key string, active ConnectionStats, closed *ConnectionStats) {
+	if st, ok := client.stats[key]; ok {
+		// Check for underflow
+		if closed.MonotonicSentBytes < st.totalSent || closed.MonotonicRecvBytes < st.totalRecv || closed.MonotonicRetransmits < st.totalRetransmits {
+			ns.telemetry.underflows++
+		} else {
+			closed.LastSentBytes = closed.MonotonicSentBytes - st.totalSent
+			closed.LastRecvBytes = closed.MonotonicRecvBytes - st.totalRecv
+			closed.LastRetransmits = closed.MonotonicRetransmits - st.totalRetransmits
+		}
+
+		// Update stats object with latest values
+		st.totalSent = active.MonotonicSentBytes
+		st.totalRecv = active.MonotonicRecvBytes
+		st.totalRetransmits = active.MonotonicRetransmits
+	} else {
+		closed.LastSentBytes = closed.MonotonicSentBytes
+		closed.LastRecvBytes = closed.MonotonicRecvBytes
+		closed.LastRetransmits = closed.MonotonicRetransmits
+	}
 }
 
 func (ns *networkState) updateConnWithStats(client *client, key string, c *ConnectionStats) {

--- a/ebpf/state.go
+++ b/ebpf/state.go
@@ -239,7 +239,7 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 			closedConn.MonotonicRetransmits += activeConn.MonotonicRetransmits
 
 			ns.createStatsForKey(client, key)
-			ns.updateConnWithStatsAndActiveConn(client, key, *activeConn, &closedConn)
+			ns.updateConnWithStatWithActiveConn(client, key, *activeConn, &closedConn)
 		} else {
 			ns.updateConnWithStats(client, key, &closedConn)
 		}
@@ -276,7 +276,9 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 	return conns
 }
 
-func (ns *networkState) updateConnWithStatsAndActiveConn(client *client, key string, active ConnectionStats, closed *ConnectionStats) {
+// This is used to update the stats when we process a closed connection that became active again
+// in this case we want the stats to reflect the new active connections in order to avoid underflows
+func (ns *networkState) updateConnWithStatWithActiveConn(client *client, key string, active ConnectionStats, closed *ConnectionStats) {
 	if st, ok := client.stats[key]; ok {
 		// Check for underflow
 		if closed.MonotonicSentBytes < st.totalSent || closed.MonotonicRecvBytes < st.totalRecv || closed.MonotonicRetransmits < st.totalRetransmits {

--- a/ebpf/state_test.go
+++ b/ebpf/state_test.go
@@ -34,7 +34,7 @@ func BenchmarkStoreClosedConnection(b *testing.B) {
 	} {
 		b.Run(fmt.Sprintf("StoreClosedConnection-%d", bench.connCount), func(b *testing.B) {
 			ns := NewDefaultNetworkState()
-			ns.Connections(DEBUGCLIENT, latestEpochTime(), []ConnectionStats{}) // Initial fetch to set up client
+			ns.Connections(DEBUGCLIENT, latestEpochTime(), nil) // Initial fetch to set up client
 
 			b.ResetTimer()
 			b.ReportAllocs()
@@ -109,7 +109,7 @@ func BenchmarkConnectionsGet(b *testing.B) {
 			ns := NewDefaultNetworkState()
 
 			// Initial fetch to set up client
-			ns.Connections(DEBUGCLIENT, latestTime, []ConnectionStats{})
+			ns.Connections(DEBUGCLIENT, latestTime, nil)
 
 			for _, c := range closed[:bench.closedCount] {
 				ns.StoreClosedConnection(c)
@@ -147,7 +147,7 @@ func TestRemoveConnections(t *testing.T) {
 
 	clientID := "1"
 	state := NewDefaultNetworkState().(*networkState)
-	conns := state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+	conns := state.Connections(clientID, latestEpochTime(), nil)
 	assert.Equal(t, 0, len(conns))
 
 	conns = state.Connections(clientID, latestEpochTime(), []ConnectionStats{conn})
@@ -183,7 +183,7 @@ func TestRetrieveClosedConnection(t *testing.T) {
 	t.Run("without prior registration", func(t *testing.T) {
 		state := NewDefaultNetworkState()
 		state.StoreClosedConnection(conn)
-		conns := state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(clientID, latestEpochTime(), nil)
 
 		assert.Equal(t, 0, len(conns))
 	})
@@ -191,21 +191,21 @@ func TestRetrieveClosedConnection(t *testing.T) {
 	t.Run("with registration", func(t *testing.T) {
 		state := NewDefaultNetworkState()
 
-		conns := state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(clientID, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		state.StoreClosedConnection(conn)
 
-		conns = state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientID, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, conn, conns[0])
 
 		// An other client that is not registered should not have the closed connection
-		conns = state.Connections("2", latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections("2", latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// It should no more have connections stored
-		conns = state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientID, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 	})
 }
@@ -219,7 +219,7 @@ func TestCleanupClient(t *testing.T) {
 	clients := state.(*networkState).getClients()
 	assert.Equal(t, 0, len(clients))
 
-	conns := state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+	conns := state.Connections(clientID, latestEpochTime(), nil)
 	assert.Equal(t, 0, len(conns))
 
 	// Should be a no op
@@ -269,11 +269,11 @@ func TestLastStats(t *testing.T) {
 	conn3.MonotonicRetransmits += dRetransmits
 
 	// First get, we should not have any connections stored
-	conns := state.Connections(client1, latestEpochTime(), []ConnectionStats{})
+	conns := state.Connections(client1, latestEpochTime(), nil)
 	assert.Equal(t, 0, len(conns))
 
 	// Same for an other client
-	conns = state.Connections(client2, latestEpochTime(), []ConnectionStats{})
+	conns = state.Connections(client2, latestEpochTime(), nil)
 	assert.Equal(t, 0, len(conns))
 
 	// We should have only one connection but with last stats equal to monotonic
@@ -344,7 +344,7 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	conn2.MonotonicRetransmits += dRetransmits
 
 	// First get, we should not have any connections stored
-	conns := state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+	conns := state.Connections(clientID, latestEpochTime(), nil)
 	assert.Equal(t, 0, len(conns))
 
 	// We should have one connection with last stats equal to monotonic stats
@@ -360,7 +360,7 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	state.StoreClosedConnection(conn2)
 
 	// We should have one connection with last stats
-	conns = state.Connections(clientID, latestEpochTime(), []ConnectionStats{})
+	conns = state.Connections(clientID, latestEpochTime(), nil)
 
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, dSent, conns[0].LastSentBytes)
@@ -450,14 +450,14 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := NewDefaultNetworkState()
 
 		// First get, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
 		state.StoreClosedConnection(conn)
 
 		// Second get, we should have monotonic and last stats = 3
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -479,7 +479,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := NewDefaultNetworkState()
 
 		// First get, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
@@ -492,13 +492,72 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(conn2)
 
 		// Second get, we should have monotonic and last stats = 8
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 8, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 8, int(conns[0].LastSentBytes))
 	})
 
-	t.Run("TwoShortlivedConnectionsCrossing", func(t *testing.T) {
+	t.Run("TwoShortlivedConnectionsCrossing-1", func(t *testing.T) {
+		// +    1 b  +  1 bytes    1 b +   1 b        +
+		// |         |                 |              |
+		// |    +-----------+      +------------+     |
+		// |         |                 |              |
+		// +         +                 +              +
+
+		// c0        c1                c2             c3
+		// We expect:
+
+		// c0: Nothing
+		// c1: Monotonic: 1 bytes, Last seen: 1 bytes
+		// c2: Monotonic: 3 bytes, Last seen: 2 bytes
+		// c3: Monotonic: 2 bytes, Last seen: 1 bytes
+
+		state := NewDefaultNetworkState()
+
+		// First get for client c, we should have nothing
+		conns := state.Connections(client, latestEpochTime(), nil)
+		assert.Len(t, conns, 0)
+
+		conn := ConnectionStats{
+			Pid:                123,
+			Type:               TCP,
+			Family:             AFINET,
+			Source:             "localhost",
+			Dest:               "localhost",
+			SPort:              9000,
+			DPort:              1234,
+			MonotonicSentBytes: 1,
+		}
+
+		// Simulate this connection starting
+		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{conn})
+		require.Len(t, conns, 1)
+		assert.EqualValues(t, 1, conns[0].LastSentBytes)
+		assert.EqualValues(t, 1, conns[0].MonotonicSentBytes)
+
+		// Store the connection as closed
+		conn.MonotonicSentBytes++
+		state.StoreClosedConnection(conn)
+
+		conn.MonotonicSentBytes = 1
+		// Retrieve the connections
+		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{conn})
+		require.Len(t, conns, 1)
+		assert.EqualValues(t, 2, conns[0].LastSentBytes)
+		assert.EqualValues(t, 3, conns[0].MonotonicSentBytes)
+
+		conn.MonotonicSentBytes++
+		// Store the connection as closed
+		state.StoreClosedConnection(conn)
+
+		conns = state.Connections(client, latestEpochTime(), nil)
+		require.Len(t, conns, 1)
+		assert.EqualValues(t, 1, conns[0].LastSentBytes)
+		assert.EqualValues(t, 2, conns[0].MonotonicSentBytes)
+	})
+
+	t.Run("TwoShortlivedConnectionsCrossing-2", func(t *testing.T) {
 		// +    3 bytes    2 b  +  3 bytes    1 b +   2 b        +
 		// |                    |                 |              |
 		// |    +-----+    +-----------+      +------------+     |
@@ -516,7 +575,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := NewDefaultNetworkState()
 
 		// First get, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
@@ -556,7 +615,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(conn3)
 
 		// 4th get, we should have monotonic = 3 and last stats = 2
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
@@ -578,7 +637,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := NewDefaultNetworkState()
 
 		// this is to register we should not have anything
-		conns := state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as opened
@@ -596,7 +655,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(conn2)
 
 		// Second get, we should have monotonic = 8 and last stats = 5
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 8, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -636,18 +695,18 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := NewDefaultNetworkState()
 
 		// First get for client c, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client d, we should have nothing
-		conns = state.Connections(clientD, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientD, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as closed
 		state.StoreClosedConnection(conn)
 
 		// Second get for client d we should have monotonic and last stats = 3
-		conns = state.Connections(clientD, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientD, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -709,13 +768,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(conn3)
 
 		// 4th get, for client c we should have monotonic = 3 and last stats = 2
-		conns = state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
 
 		// 5th get, for client d we should have monotonic = 3 and last stats = 1
-		conns = state.Connections(clientD, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientD, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 1, int(conns[0].LastSentBytes))
@@ -763,15 +822,15 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := NewDefaultNetworkState()
 
 		// First get for client c, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client d, we should have nothing
-		conns = state.Connections(clientD, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientD, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client e, we should have nothing
-		conns = state.Connections(clientE, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientE, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection
@@ -791,13 +850,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(conn)
 
 		// Second get for client d we should have monotonic and last stats = 3
-		conns = state.Connections(clientD, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientD, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
 
 		// Third get for client e we should have monotonic = 3and last stats = 1
-		conns = state.Connections(clientE, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientE, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 1, int(conns[0].LastSentBytes))
@@ -831,7 +890,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state.StoreClosedConnection(conn2)
 
 		// 4th get, for client e we should have monotonic = 5 and last stats = 5
-		conns = state.Connections(clientE, latestEpochTime(), []ConnectionStats{})
+		conns = state.Connections(clientE, latestEpochTime(), nil)
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -867,7 +926,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := NewDefaultNetworkState()
 
 		// First get for client c, we should have nothing
-		conns := state.Connections(client, latestEpochTime(), []ConnectionStats{})
+		conns := state.Connections(client, latestEpochTime(), nil)
 		assert.Equal(t, 0, len(conns))
 
 		// Second get for client c we should have monotonic and last stats = 3


### PR DESCRIPTION
I took a dump of the state / added debug logs to the tracer and got:

```
--------- network-tracer logs --------------------

network-tracer.log:11:2019-05-16 14:36:57 UTC | NETWORK | ERROR | (ebpf/state.go:305 in updateConnWithStats) | underflow occured ! p:6687|src:172.21.58.160:9000|dst:172.21.3.190:22662|f:0|t:0

---------- ebpf logs -----------------------------

ebpf.logs:64486:         foo-6740  [003] d... 674427.956290: : closing conn sport:9000, dport:22662, daddr_l:-1107094100
ebpf.logs:97361:         foo-6696  [001] d... 674572.249423: : closing conn sport:9000, dport:22662, daddr_l:-1107094100

---------- state events dump ---------------------

CLOSE: {"pid":6687,"type":0,"family":0,"net_ns":4026531957,"source":"172.21.58.160","dest":"172.21.3.190","sport":9000,"dport":22662,"direction":1,"monotonic_sent_bytes":134,"last_sent_bytes":0,"monotonic_recv_bytes":4254,"last_recv_bytes":0,"monotonic_retransmits":0,"last_retransmits":0,"last_update_epoch":674411329457181}

CONNECTION: {"pid":6687,"type":0,"family":0,"net_ns":4026531957,"source":"172.21.58.160","dest":"172.21.3.190","sport":9000,"dport":22662,"direction":1,"monotonic_sent_bytes":0,"last_sent_bytes":0,"monotonic_recv_bytes":4254,"last_recv_bytes":0,"monotonic_retransmits":0,"last_retransmits":0,"last_update_epoch":674411316811701}

CLOSE: {"pid":6687,"type":0,"family":0,"net_ns":4026531957,"source":"172.21.58.160","dest":"172.21.3.190","sport":9000,"dport":22662,"direction":1,"monotonic_sent_bytes":177,"last_sent_bytes":0,"monotonic_recv_bytes":1283,"last_recv_bytes":0,"monotonic_retransmits":0,"last_retransmits":0,"last_update_epoch":674555618757552}
```

In this case the time between the `CONNECTION` event and the second `CLOSE` event is ~140s which is less than 2mn + 30s (our expiry limit for TCP connections + our polling interval), that's why the connection was not considered expired by the userspace code.

The main issue is that the second close event has less stats than the connection event (without a connection close between the two), and there is only 2 close events for this daddr, dport couple in the eBPF logs (that relates to the 2 we have in the state dump).

(I also had a script running that took a dump of the eBPF map every 15 seconds and it didn't have any connection for this (daddr, dport) couple)

There is likely something wrong with how we deal with close events but I don't know what's the issue.

I thought it was coming from close events we would drop here https://github.com/DataDog/datadog-process-agent/blob/master/ebpf/c/tracer-ebpf.c#L557 but I added a debug log there and it was not showing up so it does not seem to be the issue.


The goal of this PR is to at least fix the issue by clearing the old stats objects when we see a connection close event (except if the connection became active again). The issue could still appear if the interval between the CONNECTION and CLOSE event is smaller than our polling interval (30s).

It also fixes an other case where we could have underflows on closed connections becoming active again.