### PR TITLE
Add retries when creating conntrack

### DIFF
--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -90,7 +90,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 	conntracker := netlink.NewNoOpConntracker()
 	if config.EnableConntrack {
 		if c, err := netlink.NewConntracker(config.ProcRoot, config.ConntrackShortTermBufferSize); err != nil {
-			log.Warnf("could not initialize conntrack, tracer will continue without NAT tracking")
+			log.Warnf("could not initialize conntrack, tracer will continue without NAT tracking", err)
 		} else {
 			conntracker = c
 		}

--- a/netlink/logging.go
+++ b/netlink/logging.go
@@ -1,0 +1,30 @@
+package netlink
+
+import (
+	"bufio"
+	"io"
+	"log"
+
+	agentlog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func getLogger() *log.Logger {
+	reader, writer := io.Pipe()
+
+	flags := 0
+	prefix := ""
+
+	logger := log.New(writer, prefix, flags)
+
+	go forwardLogs(reader)
+
+	return logger
+}
+
+func forwardLogs(rd io.Reader) {
+	scanner := bufio.NewScanner(rd)
+
+	for scanner.Scan() {
+		agentlog.Debugf("go-conntrack: %s", scanner.Text())
+	}
+}


### PR DESCRIPTION
I'm investigating a race condition where initializing conntrack
deadlocks. This is a hacky workaround that will get things working
until I find the root cause.

Also includes some logging adjustments that I made while debugging. 