### PR TITLE
Use two conntrack sockets

### DIFF
--- a/ebpf/tracer.go
+++ b/ebpf/tracer.go
@@ -90,7 +90,7 @@ func NewTracer(config *Config) (*Tracer, error) {
 	conntracker := netlink.NewNoOpConntracker()
 	if config.EnableConntrack {
 		if c, err := netlink.NewConntracker(config.ProcRoot, config.ConntrackShortTermBufferSize); err != nil {
-			log.Warnf("could not initialize conntrack, tracer will continue without NAT tracking")
+			log.Warnf("could not initialize conntrack, tracer will continue without NAT tracking", err)
 		} else {
 			conntracker = c
 		}

--- a/netlink/conntracker.go
+++ b/netlink/conntracker.go
@@ -64,7 +64,7 @@ type realConntracker struct {
 }
 
 // NewConntracker creates a new conntracker with a short term buffer capped at the given size
-func NewConntracker(procRoot string, stbSize int) (Conntracker, error) {
+func NewConntracker(procRoot string, deleteBufferSize int) (Conntracker, error) {
 	var (
 		err         error
 		conntracker Conntracker
@@ -73,7 +73,7 @@ func NewConntracker(procRoot string, stbSize int) (Conntracker, error) {
 	done := make(chan struct{})
 
 	go func() {
-		conntracker, err = newConntrackerOnce(procRoot, stbSize)
+		conntracker, err = newConntrackerOnce(procRoot, deleteBufferSize)
 		done <- struct{}{}
 	}()
 
@@ -85,8 +85,8 @@ func NewConntracker(procRoot string, stbSize int) (Conntracker, error) {
 	}
 }
 
-func newConntrackerOnce(procRoot string, stbSize int) (Conntracker, error) {
-	if stbSize <= 0 {
+func newConntrackerOnce(procRoot string, deleteBufferSize int) (Conntracker, error) {
+	if deleteBufferSize <= 0 {
 		return nil, fmt.Errorf("short term buffer size is less than 0")
 	}
 
@@ -109,7 +109,7 @@ func newConntrackerOnce(procRoot string, stbSize int) (Conntracker, error) {
 		compactTicker:       time.NewTicker(time.Hour),
 		state:               make(map[connKey]*IPTranslation),
 		shortLivedBuffer:    make(map[connKey]*IPTranslation),
-		maxShortLivedBuffer: stbSize,
+		maxShortLivedBuffer: deleteBufferSize,
 	}
 
 	// seed the state

--- a/netlink/conntracker.go
+++ b/netlink/conntracker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	ct "github.com/florianl/go-conntrack"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -80,7 +81,7 @@ func NewConntracker(procRoot string, stbSize int) (Conntracker, error) {
 	case <-done:
 		return conntracker, err
 	case <-time.After(initializationTimeout):
-		return nil, fmt.Errorf("could not initialize conntrack after %s", initializationTimeout)
+		return nil, fmt.Errorf("could not initialize conntrack after: %s", initializationTimeout)
 	}
 }
 
@@ -99,7 +100,7 @@ func newConntrackerOnce(procRoot string, stbSize int) (Conntracker, error) {
 
 	nfctDel, err := ct.Open(&ct.Config{ReadTimeout: 10 * time.Millisecond, NetNS: netns, Logger: logger})
 	if err != nil {
-		return nil, fmt.Errorf("failed to open delete NFCT", err)
+		return nil, errors.Wrap(err, "failed to open delete NFCT")
 	}
 
 	ctr := &realConntracker{

--- a/netlink/logging.go
+++ b/netlink/logging.go
@@ -8,6 +8,7 @@ import (
 	agentlog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// getLogger creates a log.Logger which forwards logs to the agent's logging package
 func getLogger() *log.Logger {
 	reader, writer := io.Pipe()
 

--- a/netlink/logging.go
+++ b/netlink/logging.go
@@ -4,12 +4,19 @@ import (
 	"bufio"
 	"io"
 	"log"
+	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	agentlog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// getLogger creates a log.Logger which forwards logs to the agent's logging package
+// getLogger creates a log.Logger which forwards logs to the agent's logging package at DEBUG leve.
+// Returns nil if the agent loggers level is above DEBUG.
 func getLogger() *log.Logger {
+	if level := strings.ToUpper(config.Datadog.GetString("log_level")); level != "DEBUG" {
+		return nil
+	}
+
 	reader, writer := io.Pipe()
 
 	flags := 0

--- a/netlink/logging.go
+++ b/netlink/logging.go
@@ -1,0 +1,30 @@
+package netlink
+
+import (
+	"bufio"
+	"io"
+	"log"
+
+	agentlog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func getLogger() *log.Logger {
+	reader, writer := io.Pipe()
+
+	flags := 0
+	prefix := ""
+
+	logger := log.New(writer, prefix, flags)
+
+	go forwardLogs(reader)
+
+	return logger
+}
+
+func forwardLogs(rd io.Reader) {
+	scanner := bufio.NewScanner(rd)
+
+	for scanner.Scan() {
+		agentlog.Debugf("go-conntrack: %s", scanner.Text())
+	}
+}


### PR DESCRIPTION
go-conntrack has issues when we register two callbacks. To fix it, we
can use two conntrack connections.

I also included some logging improvements that were useful when debugging this.