### PR TITLE
Allow for hostname to be passed as encrypted environment variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -261,11 +261,6 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 		cfg.LogLevel = "warn"
 	}
 
-	if v := os.Getenv("DD_HOSTNAME"); v != "" {
-		log.Info("overriding hostname from env DD_HOSTNAME value")
-		cfg.HostName = v
-	}
-
 	if cfg.HostName == "" {
 		if ecsutil.IsFargateInstance() {
 			// Fargate tasks should have no concept of host names, so we're using the task ARN.
@@ -323,6 +318,8 @@ func NewNetworkAgentConfig(loggerName config.LoggerName, yamlPath string) (*Agen
 
 func loadEnvVariables() {
 	for envKey, cfgKey := range map[string]string{
+		"DD_HOSTNAME": "hostname",
+
 		"DD_PROCESS_AGENT_ENABLED":          "process_config.enabled",
 		"DD_PROCESS_AGENT_CONTAINER_SOURCE": "process_config.container_source",
 		"DD_SCRUB_ARGS":                     "process_config.scrub_args",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -298,6 +298,7 @@ func TestAgentConfigYamlAndNetworkConfig(t *testing.T) {
 
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
+	assert.Equal("server-01", agentConfig.HostName)
 	assert.Equal(10, agentConfig.QueueSize)
 	assert.Equal(true, agentConfig.AllowRealTime)
 	assert.Equal(true, agentConfig.Enabled)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -250,7 +250,9 @@ func TestAgentEncryptedVariablesSecrets(t *testing.T) {
 	config.Datadog.Set("secret_backend_output_max_size", 1024)
 
 	os.Setenv("DD_API_KEY", "ENC[my_api_key]")
+	os.Setenv("DD_HOSTNAME", "ENC[my_host]")
 	defer os.Unsetenv("DD_API_KEY")
+	defer os.Unsetenv("DD_HOSTNAME")
 
 	assert := assert.New(t)
 	agentConfig, err := NewAgentConfig(
@@ -261,6 +263,7 @@ func TestAgentEncryptedVariablesSecrets(t *testing.T) {
 	assert.Equal("secret_my_api_key", config.Datadog.Get("api_key"))
 	ep := agentConfig.APIEndpoints[0]
 	assert.Equal("secret_my_api_key", ep.APIKey)
+	assert.Equal("secret_my_host", agentConfig.HostName)
 }
 
 func TestAgentConfigYamlAndNetworkConfig(t *testing.T) {

--- a/config/testdata/TestDDAgentConfigYamlAndNetworkConfig.yaml
+++ b/config/testdata/TestDDAgentConfigYamlAndNetworkConfig.yaml
@@ -1,4 +1,5 @@
 api_key: apikey_20
+hostname: server-01
 
 process_agent_enabled: true
 process_config:

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -103,6 +103,10 @@ func (a *AgentConfig) loadProcessYamlConfig(path string) error {
 		a.APIEndpoints[0].APIKey = config.Datadog.GetString(key)
 	}
 
+	if config.Datadog.IsSet("hostname") {
+		a.HostName = config.Datadog.GetString("hostname")
+	}
+
 	if k := key(ns, "enabled"); config.Datadog.IsSet(k) {
 		// A string indicate the enabled state of the Agent.
 		// If "false" (the default) we will only collect containers.


### PR DESCRIPTION
We were overwriting the hostname with whatever was passed as an environment variable. This should fix that.